### PR TITLE
Model Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Embeddings Service
 
 This is a Foxx service that enables the generation of embeddings
+
+### Installation/Development:
+The easiest way to get started is by first installing the Foxx
+cli:
+
+```npm install --global foxx-cli```
+
+You can then install the Foxx service on your ArangoDB instance:
+
+```foxx install /embeddings .```
+
+The installed Foxx service can then be viewed in the ArangoDB UI.
+
+To update your microservice with any changes you've made, please run:
+
+```foxx upgrade /embeddings .```

--- a/main.js
+++ b/main.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const {context} = require("@arangodb/locals");
+const createRouter = require("@arangodb/foxx/router");
+const joi = require("joi");
+
+const router = createRouter();
+context.use(router);

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "engines": {
+    "arangodb": "^3.0.0"
+  },
+  "main": "main.js",
+  "scripts": {
+    "setup": "scripts/setup.js"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "embeddings-service",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/arangodb": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@types/arangodb/-/arangodb-3.5.13.tgz",
+      "integrity": "sha512-1V0vsxzW7dncL0wC+jCgEWKdvmUZthEd79yzw8vgCR6X0jVtZUsJP2CYnuBeOSXGFFeLz0hKKD3uP66bjc49zw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
+      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "embeddings-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/arangoml/embeddings-service.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/arangoml/embeddings-service/issues"
+  },
+  "homepage": "https://github.com/arangoml/embeddings-service#readme",
+  "dependencies": {
+    "@types/arangodb": "^3.5.13"
+  }
+}

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -5,13 +5,6 @@ const {context} = require("@arangodb/locals");
 
 const METADATA_DOC_COLLECTION = context.collectionName("_model_metadata");
 
-function createModelMetadataCollection() {
-    if (!db._collection(METADATA_DOC_COLLECTION)) {
-        db._createDocumentCollection(METADATA_DOC_COLLECTION);
-    }
-    return db._collection(METADATA_DOC_COLLECTION);
-}
-
 const modelTypes = {
     WORD_EMBEDDING: "word_embedding_model",
     GRAPH_MODEL: "graph_embedding_model"
@@ -19,26 +12,63 @@ const modelTypes = {
 
 exports.modelTypes = modelTypes;
 
+const modelMetadataSchema = {
+    rule: {
+        "type": "object",
+        "properties": {
+            "model_type": { "enum": [modelTypes.WORD_EMBEDDING, modelTypes.GRAPH_MODEL] },
+            "name": { "type": "string" },
+            "emb_dim": { "type": "number" },
+            "invocation_name": { "type": "string" },
+            "framework": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                },
+                "required": ["name"]
+            },
+            "website": { "type": "string" }
+        },
+        "required": ["model_type", "name", "emb_dim", "invocation_name", "framework"]
+    },
+    level: "moderate",
+    message: "The model's metadata is invalid"
+};
+
+function createModelMetadataCollection() {
+    if (!db._collection(METADATA_DOC_COLLECTION)) {
+        db._createDocumentCollection(METADATA_DOC_COLLECTION, { "schema": modelMetadataSchema });
+    }
+    return db._collection(METADATA_DOC_COLLECTION);
+}
+
 const seedData = [
     {
-        type: modelTypes.WORD_EMBEDDING,
-        name: "DistilBERT",
-        _key: "DistilBERT",
+        model_type: modelTypes.WORD_EMBEDDING,
+        name: "distilbert-base-uncased",
+        _key: "distilbert-base-uncased",
+        framework: {
+            name: "pytorch"
+        },
         emb_dim: 768,
+        website: "https://huggingface.co/distilbert-base-uncased",
         // This is the name that this model will have on the compute node. May differ from display name
-        invocation_name: "DistilBERT"
+        invocation_name: "distilbert-base-uncased"
     },
     {
-        type: modelTypes.GRAPH_MODEL,
-        name: "GraphSAGE",
-        _key: "GraphSAGE",
+        model_type: modelTypes.GRAPH_MODEL,
+        name: "graph-sage",
+        _key: "graph-sage",
+        framework: {
+            name: "pytorch"
+        },
         emb_dim: 64,
-        invocation_name: "GraphSAGE"
+        invocation_name: "graph-sage"
     }
 ];
 
 function seedMetadataCol(collection) {
-    collection.insert(seedData, { waitForSync: true });
+    collection.insert(seedData);
 }
 
 const modelMetadataCol = createModelMetadataCollection();

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const db = require("@arangodb").db;
+const {context} = require("@arangodb/locals");
+
+const METADATA_DOC_COLLECTION = context.collectionName("_model_metadata");
+
+function createModelMetadataCollection() {
+    if (!db._collection(METADATA_DOC_COLLECTION)) {
+        db._createDocumentCollection(METADATA_DOC_COLLECTION);
+    }
+    return db._collection(METADATA_DOC_COLLECTION);
+}
+
+const modelTypes = {
+    WORD_EMBEDDING: "word_embedding_model",
+    GRAPH_MODEL: "graph_embedding_model"
+};
+
+exports.modelTypes = modelTypes;
+
+const seedData = [
+    {
+        type: modelTypes.WORD_EMBEDDING,
+        name: "DistilBERT",
+        _key: "DistilBERT",
+        emb_dim: 768
+    },
+    {
+        type: modelTypes.GRAPH_MODEL,
+        name: "GraphSAGE",
+        _key: "GraphSAGE",
+        emb_dim: 64
+    }
+];
+
+function seedMetadataCol(collection) {
+    collection.insert(seedData, { waitForSync: true });
+}
+
+const modelMetadataCol = createModelMetadataCollection();
+seedMetadataCol(modelMetadataCol);

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -24,13 +24,16 @@ const seedData = [
         type: modelTypes.WORD_EMBEDDING,
         name: "DistilBERT",
         _key: "DistilBERT",
-        emb_dim: 768
+        emb_dim: 768,
+        // This is the name that this model will have on the compute node. May differ from display name
+        invocation_name: "DistilBERT"
     },
     {
         type: modelTypes.GRAPH_MODEL,
         name: "GraphSAGE",
         _key: "GraphSAGE",
-        emb_dim: 64
+        emb_dim: 64,
+        invocation_name: "GraphSAGE"
     }
 ];
 


### PR DESCRIPTION
This PR adds a placeholder Foxx service with a model metadata setup script.

This setup script creates the model metadata collection and seeds it with some initial values. (These are up for discussion :))

The two kinds of models that will currently be supported are:
* Word Embedding models
* Graph Embedding models