### PR TITLE
Node embeddings integration

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -4,6 +4,7 @@ const createRouter = require("@arangodb/foxx/router");
 const joi = require("joi");
 const {listModels} = require("../controllers/list_models");
 const {generateEmbeddings} = require("../controllers/generate_embeddings");
+const {embeddingsStatusesForModel, embeddingsStatusById} = require("../controllers/embeddings_status");
 const {modelTypes} = require("../model/model_metadata");
 
 const router = createRouter();
@@ -54,6 +55,41 @@ router.post("/generate_embeddings", generateEmbeddings)
         joi.object({
             message: joi.string(),
             embeddings_status_id: joi.string()
+        })
+    );
+
+router.get("/embeddings_status/:statusId", embeddingsStatusById)
+    .pathParam("statusId", joi.string().required(), "ID of embeddings generation status")
+    .response(
+        404,
+        joi.string(),
+        "Not found"
+    )
+    .response(200,
+        joi.object({
+            status: joi.string(),
+            documentCollection: joi.string(),
+            embeddingsCollection: joi.string(),
+            embeddingsFieldName: joi.string()
+        })
+    );
+
+router.get("/embeddings_status", embeddingsStatusesForModel)
+    .queryParam("modelName", joi.string().required())
+    .queryParam("modelType", joi.string().required())
+    .queryParam("collectionName", joi.string().required())
+    .queryParam("fieldName", joi.string().required())
+    .response(
+        404,
+        joi.string(),
+        "Not found"
+    )
+    .response(200,
+        joi.object({
+            status: joi.string(),
+            documentCollection: joi.string(),
+            embeddingsCollection: joi.string(),
+            embeddingsFieldName: joi.string()
         })
     );
 

--- a/api/router.js
+++ b/api/router.js
@@ -50,7 +50,12 @@ router.post("/generate_embeddings", generateEmbeddings)
         422,
         joi.string(),
         "Invalid input"
-    ).response(200, joi.string());
+    ).response(200,
+        joi.object({
+            message: joi.string(),
+            embeddings_status_id: joi.string()
+        })
+    );
 
 router.get("/models", listModels)
     .response(

--- a/api/router.js
+++ b/api/router.js
@@ -19,7 +19,8 @@ router.post("/generate_embeddings", generateEmbeddings)
             // then pick field
             // (for graph embeddings this is a set of features, for word embeddings this is a text field)
             fieldName: joi.string().required(),
-            separateCollection: joi.bool().default(true)
+            separateCollection: joi.bool().default(true),
+            overwriteExisting: joi.bool().default(false),
         }).required(),
         // This seems to be encased in a "value" object in the swagger doc
         // .example([{
@@ -39,6 +40,8 @@ router.post("/generate_embeddings", generateEmbeddings)
          \`fieldName\`: name of the field to embed. For graph embeddings this is a feature vector, for word embeddings this is a string.
          \`separateCollection\`: whether or not to store embeddings in a separate collection - \`true\` by default. If set to false, the embeddings
          \twill be stored on the documents in the specified collection.
+         \`overwriteExisting\`: \`false\` by default. If set to \`true\` then this will overwrite existing embeddings for the collection+field+model combination
+         \t if it exists.
          `
     ).response(
         400,

--- a/api/router.js
+++ b/api/router.js
@@ -18,7 +18,8 @@ router.post("/generate_embeddings", generateEmbeddings)
             graphName: joi.string(),
             // then pick field
             // (for graph embeddings this is a set of features, for word embeddings this is a text field)
-            fieldName: joi.string().required()
+            fieldName: joi.string().required(),
+            separateCollection: joi.bool().default(true)
         }).required(),
         // This seems to be encased in a "value" object in the swagger doc
         // .example([{
@@ -36,6 +37,8 @@ router.post("/generate_embeddings", generateEmbeddings)
          \`collectionName\`: name of the collection that you want to embed
          \`graphName\`: name of the graph that you want to embed (please note: not required if generating node specific features e.g. word embeddings)
          \`fieldName\`: name of the field to embed. For graph embeddings this is a feature vector, for word embeddings this is a string.
+         \`separateCollection\`: whether or not to store embeddings in a separate collection - \`true\` by default. If set to false, the embeddings
+         \twill be stored on the documents in the specified collection.
          `
     ).response(
         400,

--- a/controllers/embeddings_status.js
+++ b/controllers/embeddings_status.js
@@ -1,3 +1,4 @@
+"use strict";
 const {getStatusByKey} = require("../db/embeddings_status");
 const {getStatusesByCollectionAndEmbName} = require("../db/embeddings_status");
 const {retrieveModel} = require("../services/model_metadata_service");
@@ -18,7 +19,7 @@ function embeddingsStatusesForModel(req, res) {
         getEmbeddingsFieldName(fieldName, modelMetadata)
     );
 
-    if (statuses.length == 0) {
+    if (statuses.length === 0) {
         res.throw(404, "Status not found");
     }
     res.json(statuses);

--- a/controllers/embeddings_status.js
+++ b/controllers/embeddings_status.js
@@ -1,0 +1,45 @@
+const {query, db} = require("@arangodb");
+const {embeddingsStatusCollectionName} = require("../model/embeddings_status");
+const {retrieveModel} = require("../services/model_metadata_service");
+const {getEmbeddingsFieldName} = require("../services/emb_collections_service");
+const {sendInvalidInputMessage} = require("../utils/invalid_input");
+
+function embeddingsStatusesForModel(req, res) {
+    const {modelName, modelType, collectionName, fieldName} = req.queryParams;
+    const modelMetadata = retrieveModel(modelName, modelType);
+
+    if (modelMetadata == null) {
+        sendInvalidInputMessage(res,
+            `Invalid model: ${modelName} of type ${modelType}`);
+    }
+
+    const col = db._collection(embeddingsStatusCollectionName);
+    const statuses = query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.emb_field_name == ${getEmbeddingsFieldName(fieldName, modelMetadata)}
+        RETURN d
+    `.toArray();
+    if (statuses.length == 0) {
+        res.throw(404, "Status not found");
+    }
+    res.json(statuses);
+}
+
+function embeddingsStatusById(req, res) {
+    const {statusId} = req.pathParams;
+
+    const col = db._collection(embeddingsStatusCollectionName);
+    const statuses = query`
+    FOR d in ${col}
+        FILTER d._key == ${statusId}
+        RETURN d
+    `.toArray();
+    if (statuses.length == 0) {
+        res.throw(404, "Status not found");
+    }
+    res.json(statuses[0]);
+}
+
+exports.embeddingsStatusesForModel = embeddingsStatusesForModel;
+exports.embeddingsStatusById = embeddingsStatusById;

--- a/controllers/embeddings_status.js
+++ b/controllers/embeddings_status.js
@@ -1,5 +1,5 @@
-const {query, db} = require("@arangodb");
-const {embeddingsStatusCollectionName} = require("../model/embeddings_status");
+const {getStatusByKey} = require("../db/embeddings_status");
+const {getStatusesByCollectionAndEmbName} = require("../db/embeddings_status");
 const {retrieveModel} = require("../services/model_metadata_service");
 const {getEmbeddingsFieldName} = require("../services/emb_collections_service");
 const {sendInvalidInputMessage} = require("../utils/invalid_input");
@@ -13,13 +13,11 @@ function embeddingsStatusesForModel(req, res) {
             `Invalid model: ${modelName} of type ${modelType}`);
     }
 
-    const col = db._collection(embeddingsStatusCollectionName);
-    const statuses = query`
-    FOR d in ${col}
-        FILTER d.collection == ${collectionName}
-        AND d.emb_field_name == ${getEmbeddingsFieldName(fieldName, modelMetadata)}
-        RETURN d
-    `.toArray();
+    const statuses = getStatusesByCollectionAndEmbName(
+        collectionName,
+        getEmbeddingsFieldName(fieldName, modelMetadata)
+    );
+
     if (statuses.length == 0) {
         res.throw(404, "Status not found");
     }
@@ -29,16 +27,11 @@ function embeddingsStatusesForModel(req, res) {
 function embeddingsStatusById(req, res) {
     const {statusId} = req.pathParams;
 
-    const col = db._collection(embeddingsStatusCollectionName);
-    const statuses = query`
-    FOR d in ${col}
-        FILTER d._key == ${statusId}
-        RETURN d
-    `.toArray();
-    if (statuses.length == 0) {
+    const status = getStatusByKey(statusId);
+    if (status == null) {
         res.throw(404, "Status not found");
     }
-    res.json(statuses[0]);
+    res.json(status);
 }
 
 exports.embeddingsStatusesForModel = embeddingsStatusesForModel;

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -2,6 +2,7 @@
 
 const {db} = require("@arangodb");
 const graph_module = require("@arangodb/general-graph");
+const {updateEmbeddingsStatus} = require("../services/emb_status_service");
 const {modelTypes} = require("../model/model_metadata");
 const {embeddingsStatus} = require("../model/embeddings_status");
 const {sendInvalidInputMessage} = require("../utils/invalid_input");
@@ -48,7 +49,10 @@ function handleGenerationForModel(embStatus, graphName, collectionName, fieldNam
         case embeddingsStatus.RUNNING_FAILED:
             return "Generation of embeddings is already running!";
         case embeddingsStatus.COMPLETED:
-            return "These embeddings have already been generated!";
+            // Overwrite by default
+            updateEmbeddingsStatus(embStatus.RUNNING, collectionName, destinationCollectionName, fieldName, modelMetadata);
+            return generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata);
+        //     return "These embeddings have already been generated!";
     }
 }
 

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const {db} = require("@arangodb");
-const graph_module = require("@arangodb/general-graph");
+const {checkCollectionIsPresent, checkGraphIsPresent} = require("../utils/db");
 const {updateEmbeddingsStatus} = require("../services/emb_status_service");
 const {modelTypes} = require("../model/model_metadata");
 const {embeddingsStatus} = require("../model/embeddings_status");
@@ -30,13 +29,6 @@ function initialValidationGenerateEmbParams(req, res) {
     }
 }
 
-function checkGraphIsPresent(graphName) {
-    return graph_module._list().some(g => g === graphName)
-}
-
-function checkCollectionIsPresent(collectionName) {
-    return db._collections().map(c => c.name()).some(n => n === collectionName)
-}
 
 function handleGenerationForModel(embStatus, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata, overwriteExisting) {
     let response_dict = {};

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -2,11 +2,13 @@
 
 const {db} = require("@arangodb");
 const graph_module = require("@arangodb/general-graph");
-const {generateBatchesForModel} = require("../services/emb_generation_service");
-const {getDestinationCollectionName} = require("../services/emb_collections_service");
 const {modelTypes} = require("../model/model_metadata");
+const {embeddingsStatus} = require("../model/embeddings_status");
 const {sendInvalidInputMessage} = require("../utils/invalid_input");
 const {retrieveModel} = require("../services/model_metadata_service");
+const {getEmbeddingsStatus, createEmbeddingsStatus} = require("../services/emb_status_service");
+const {generateBatchesForModel} = require("../services/emb_generation_service");
+const {getDestinationCollectionName} = require("../services/emb_collections_service");
 
 function initialValidationGenerateEmbParams(req, res) {
     // check if model type is valid
@@ -35,6 +37,21 @@ function checkCollectionIsPresent(collectionName) {
     return db._collections().map(c => c.name()).some(n => n === collectionName)
 }
 
+function handleGenerationForModel(embStatus, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata) {
+    switch (embStatus) {
+        case embeddingsStatus.DOES_NOT_EXIST:
+            createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata);
+            return generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata);
+        case embeddingsStatus.FAILED:
+            return generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata);
+        case embeddingsStatus.RUNNING:
+        case embeddingsStatus.RUNNING_FAILED:
+            return "Generation of embeddings is already running!";
+        case embeddingsStatus.COMPLETED:
+            return "These embeddings have already been generated!";
+    }
+}
+
 function generateEmbeddings(req, res) {
     initialValidationGenerateEmbParams(req, res);
 
@@ -60,7 +77,8 @@ function generateEmbeddings(req, res) {
     }
 
     const destinationCollectionName = getDestinationCollectionName(collectionName, separateCollection, modelMetadata);
-    const message = generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata);
+    const embStatus = getEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata);
+    const message = handleGenerationForModel(embStatus, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata)
     res.json(message);
 }
 

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -61,11 +61,12 @@ function handleGenerationForModel(embStatus, graphName, collectionName, fieldNam
         case embeddingsStatus.COMPLETED:
             // Overwrite by default
             if (!overwriteExisting) {
-                return "These embeddings have already been generated!";
-            }
-            updateEmbeddingsStatus(embeddingsStatus.RUNNING, collectionName, destinationCollectionName, fieldName, modelMetadata);
-            if (generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata)) {
-                response_dict["message"] = "Overwriting old embeddings. " + start_msg;
+                response_dict["message"] = "These embeddings have already been generated!";
+            } else {
+                updateEmbeddingsStatus(embeddingsStatus.RUNNING, collectionName, destinationCollectionName, fieldName, modelMetadata);
+                if (generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata)) {
+                    response_dict["message"] = "Overwriting old embeddings. " + start_msg;
+                }
             }
             break;
     }

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -44,15 +44,16 @@ function handleGenerationForModel(embStatus, graphName, collectionName, fieldNam
             createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata);
             return generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata);
         case embeddingsStatus.FAILED:
+            updateEmbeddingsStatus(embeddingsStatus.RUNNING, collectionName, destinationCollectionName, fieldName, modelMetadata);
             return generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata);
         case embeddingsStatus.RUNNING:
         case embeddingsStatus.RUNNING_FAILED:
             return "Generation of embeddings is already running!";
         case embeddingsStatus.COMPLETED:
             // Overwrite by default
-            updateEmbeddingsStatus(embStatus.RUNNING, collectionName, destinationCollectionName, fieldName, modelMetadata);
+            updateEmbeddingsStatus(embeddingsStatus.RUNNING, collectionName, destinationCollectionName, fieldName, modelMetadata);
             return generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata);
-        //     return "These embeddings have already been generated!";
+            // return "These embeddings have already been generated!";
     }
 }
 
@@ -82,7 +83,7 @@ function generateEmbeddings(req, res) {
 
     const destinationCollectionName = getDestinationCollectionName(collectionName, separateCollection, modelMetadata);
     const embStatus = getEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata);
-    const message = handleGenerationForModel(embStatus, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata)
+    const message = handleGenerationForModel(embStatus, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata);
     res.json(message);
 }
 

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -1,3 +1,6 @@
+/**
+ * This module is responsible for queries interacting with the Embeddings status metadata collection
+ */
 "use strict";
 const {query, db} = require("@arangodb");
 const {embeddingsStatusCollectionName} = require("../model/embeddings_status");
@@ -26,5 +29,43 @@ function getStatusesByCollectionAndEmbName(collectionName, embeddingsFieldName) 
     return statuses;
 }
 
+function getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, embeddingsFieldName) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    const res = query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.destination_collection == ${destinationCollectionName}
+        AND d.emb_field_name == ${embeddingsFieldName}
+        RETURN d
+    `.toArray();
+    return res;
+}
+
+function createStatus(collectionName, destinationCollectionName, embeddingsFieldName, status) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    query`
+    INSERT {
+        collection: ${collectionName},
+        destination_collection: ${destinationCollectionName},
+        emb_field_name: ${embeddingsFieldName},
+        status: ${status}
+    } INTO ${col}
+    `;
+}
+
+function updateStatusByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, embeddingsFieldName, newStatus) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.destination_collection == ${destinationCollectionName}
+        AND d.emb_field_name == ${embeddingsFieldName}
+        UPDATE d._key WITH { status: ${newStatus} } IN ${col}
+    `;
+}
+
 exports.getStatusByKey = getStatusByKey;
 exports.getStatusesByCollectionAndEmbName = getStatusesByCollectionAndEmbName;
+exports.getStatusesByCollectionDestinationAndEmbName = getStatusesByCollectionDestinationAndEmbName;
+exports.createStatus = createStatus;
+exports.updateStatusByCollectionDestinationAndEmbName = updateStatusByCollectionDestinationAndEmbName;

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -1,0 +1,30 @@
+"use strict";
+const {query, db} = require("@arangodb");
+const {embeddingsStatusCollectionName} = require("../model/embeddings_status");
+
+function getStatusByKey(key) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    const statuses = query`
+    FOR d in ${col}
+        FILTER d._key == ${key}
+        RETURN d
+    `.toArray();
+    if (statuses.length == 0) {
+        return null;
+    }
+    return statuses[0];
+}
+
+function getStatusesByCollectionAndEmbName(collectionName, embeddingsFieldName) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    const statuses = query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.emb_field_name == ${embeddingsFieldName}
+        RETURN d
+    `.toArray();
+    return statuses;
+}
+
+exports.getStatusByKey = getStatusByKey;
+exports.getStatusesByCollectionAndEmbName = getStatusesByCollectionAndEmbName;

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -12,7 +12,7 @@ function getStatusByKey(key) {
         FILTER d._key == ${key}
         RETURN d
     `.toArray();
-    if (statuses.length == 0) {
+    if (statuses.length === 0) {
         return null;
     }
     return statuses[0];
@@ -20,25 +20,23 @@ function getStatusByKey(key) {
 
 function getStatusesByCollectionAndEmbName(collectionName, embeddingsFieldName) {
     const col = db._collection(embeddingsStatusCollectionName);
-    const statuses = query`
+    return query`
     FOR d in ${col}
         FILTER d.collection == ${collectionName}
         AND d.emb_field_name == ${embeddingsFieldName}
         RETURN d
     `.toArray();
-    return statuses;
 }
 
 function getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, embeddingsFieldName) {
     const col = db._collection(embeddingsStatusCollectionName);
-    const res = query`
+    return query`
     FOR d in ${col}
         FILTER d.collection == ${collectionName}
         AND d.destination_collection == ${destinationCollectionName}
         AND d.emb_field_name == ${embeddingsFieldName}
         RETURN d
     `.toArray();
-    return res;
 }
 
 function createStatus(collectionName, destinationCollectionName, embeddingsFieldName, status) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,16 @@
 {
+  "$schema": "http://json.schemastore.org/foxx-manifest",
   "engines": {
     "arangodb": "^3.0.0"
   },
   "main": "main.js",
+  "configuration": {
+    "embeddingService": {
+      "type": "string",
+      "default": "http://localhost:8000",
+      "description": "URL of the embeddings service"
+    }
+  },
   "scripts": {
     "setup": "scripts/setup.js",
     "createNodeEmbeddings": "scripts/create_node_embeddings.js",

--- a/model/embeddings_status.js
+++ b/model/embeddings_status.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const {context} = require("@arangodb/locals");
+
+const embeddingsStatus = {
+    RUNNING: "running",
+    RUNNING_FAILED: "running_failed",
+    FAILED: "failed",
+    COMPLETED: "completed",
+};
+
+const embeddingsStatusCollectionName = context.collectionName("_status");
+const embeddingsStatusSchema = {
+    rule: {
+        "type": "object",
+        "properties": {
+            "emb_field_name": { "type": "string" },
+            "collection": { "type": "string" },
+            "status": { "enum": [
+                    embeddingsStatus.RUNNING,
+                    embeddingsStatus.RUNNING_FAILED,
+                    embeddingsStatus.FAILED,
+                    embeddingsStatus.COMPLETED,
+                ] }
+        },
+        "required": ["emb_field_name", "collection", "status"]
+    },
+    level: "moderate",
+    message: "The embeddings status is invalid"
+};
+
+exports.embeddingsStatusCollectionName = embeddingsStatusCollectionName;
+exports.embeddingsStatusSchema = embeddingsStatusSchema;

--- a/model/embeddings_status.js
+++ b/model/embeddings_status.js
@@ -7,6 +7,7 @@ const embeddingsStatus = {
     RUNNING_FAILED: "running_failed",
     FAILED: "failed",
     COMPLETED: "completed",
+    DOES_NOT_EXIST: "do_not_exist"
 };
 
 const embeddingsStatusCollectionName = context.collectionName("_status");
@@ -16,6 +17,7 @@ const embeddingsStatusSchema = {
         "properties": {
             "emb_field_name": { "type": "string" },
             "collection": { "type": "string" },
+            "destination_collection": { "type": "string" },
             "status": { "enum": [
                     embeddingsStatus.RUNNING,
                     embeddingsStatus.RUNNING_FAILED,
@@ -23,11 +25,12 @@ const embeddingsStatusSchema = {
                     embeddingsStatus.COMPLETED,
                 ] }
         },
-        "required": ["emb_field_name", "collection", "status"]
+        "required": ["emb_field_name", "collection", "destination_collection", "status"]
     },
     level: "moderate",
     message: "The embeddings status is invalid"
 };
 
+exports.embeddingsStatus = embeddingsStatus;
 exports.embeddingsStatusCollectionName = embeddingsStatusCollectionName;
 exports.embeddingsStatusSchema = embeddingsStatusSchema;

--- a/model/model_metadata.js
+++ b/model/model_metadata.js
@@ -40,6 +40,7 @@ const modelMetadataSchema = {
                 "type": "object",
                 "properties": {
                     "emb_dim": { "type": "number" },
+                    "inference_batch_size": { "type": "number" },
                     "schema": {
                         "type": "object",
                         "properties": {
@@ -67,7 +68,7 @@ const modelMetadataSchema = {
                         }
                     }
                 },
-                "required": ["emb_dim"]
+                "required": ["emb_dim", "inference_batch_size"]
             },
             "train": {
                 "type": "object",

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -1,7 +1,7 @@
 "use strict";
 const {query, db} = require("@arangodb");
 const request = require("@arangodb/request");
-const {getEmbeddingsFieldName} = require("../services/emb_collections_service");
+const {getEmbeddingsFieldName, deleteEmbeddingsFieldEntries} = require("../services/emb_collections_service");
 const {getEmbeddingsStatus, updateEmbeddingsStatus} = require("../services/emb_status_service");
 const {embeddingsStatus} = require("../model/embeddings_status");
 const {context} = require("@arangodb/locals");
@@ -116,15 +116,7 @@ function insertEmbeddingsIntoDBSepCollection(docsWithKey, calculatedEmbeddings, 
 
 function rollbackGeneratedEmbeddings(destinationCollectionName, fieldName, modelMetadata) {
     console.log("Rolling back existing embeddings");
-    const dCol = db._collection(destinationCollectionName);
-
-    const embedding_field_name = getEmbeddingsFieldName(fieldName, modelMetadata);
-
-    query`
-    FOR doc in ${dCol}
-      FILTER doc[${embedding_field_name}] != null
-      UPDATE doc WITH { ${embedding_field_name}: null } IN ${dCol} OPTIONS { keepNull: false }
-    `;
+    deleteEmbeddingsFieldEntries(destinationCollectionName, fieldName, modelMetadata);
 }
 
 function handleFailure(currentBatchFailed, isTheLastBatch, collectionName, destinationCollectionName, fieldName, modelMetadata) {

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -14,7 +14,7 @@ const MAX_RETRIES = 5;
 function getDocumentsToEmbed(nDocs, startInd, collection, fieldToEmbed) {
     const start_index = startInd * nDocs;
 
-    const toEmbed = query`
+    return query`
     FOR doc in ${collection}
         FILTER doc.${fieldToEmbed} != null
         LIMIT ${start_index}, ${nDocs}
@@ -23,7 +23,6 @@ function getDocumentsToEmbed(nDocs, startInd, collection, fieldToEmbed) {
           "field": doc.${fieldToEmbed}
         }
     `.toArray();
-    return toEmbed;
 }
 
 function formatBatch(batchData) {
@@ -44,7 +43,7 @@ function invokeEmbeddingModel(dataToEmbed) {
     let tries = 0;
     let res = {"status": -1};
 
-    while (res.status != 200 && tries < MAX_RETRIES) {
+    while (res.status !== 200 && tries < MAX_RETRIES) {
         const now = new Date().getTime();
         while (new Date().getTime() < now + tries) {
             // NOP
@@ -130,7 +129,7 @@ function handleFailure(currentBatchFailed, isTheLastBatch, collectionName, desti
     }
 }
 
-if (getEmbeddingsStatus(collectionName, destinationCollection, fieldName, modelMetadata) == embeddingsStatus.RUNNING_FAILED) {
+if (getEmbeddingsStatus(collectionName, destinationCollection, fieldName, modelMetadata) === embeddingsStatus.RUNNING_FAILED) {
     console.log(`Generation failed, skipping batch ${batchIndex}`);
     handleFailure(false, isLastBatch, collectionName, destinationCollection, fieldName, modelMetadata);
 } else {
@@ -142,7 +141,7 @@ if (getEmbeddingsStatus(collectionName, destinationCollection, fieldName, modelM
         const requestData = toEmbed.map(x => x["field"]);
         const res = invokeEmbeddingModel(requestData);
 
-        if (res.status == 200) {
+        if (res.status === 200) {
             const embeddings = extractEmbeddingsFromResponse(res.body, modelMetadata.metadata.emb_dim);
             if (separateCollection) {
                 const dCollection = db._collection(destinationCollection);

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -52,7 +52,7 @@ function chunkArray(array, chunk_size) {
 }
 
 function extractEmbeddingsFromResponse(response_json, embedding_dim) {
-    // TODO: this is brittle, outputs may differ per model
+    // N.B. this is brittle, do output formats differ per model?
     const output = JSON.parse(response_json);
     const giant_arr = output["outputs"][0]["data"];
     return chunkArray(giant_arr, embedding_dim);
@@ -82,5 +82,9 @@ const collection = db._collection(collectionName)
 const toEmbed = getDocumentsToEmbed(batchSize, batchIndex, collection, fieldName);
 const requestData = toEmbed.map(x => x["field"]);
 const res = invokeEmbeddingModel(requestData);
-const embeddings = extractEmbeddingsFromResponse(res.body, modelMetadata.metadata.emb_dim);
-insertEmbeddingsIntoDBSameCollection(toEmbed, embeddings, collection, modelMetadata);
+if (res.status == 200) {
+    const embeddings = extractEmbeddingsFromResponse(res.body, modelMetadata.metadata.emb_dim);
+    insertEmbeddingsIntoDBSameCollection(toEmbed, embeddings, collection, modelMetadata);
+} else {
+    console.error("Failed to get requested embeddings!!");
+}

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -1,7 +1,86 @@
 "use strict";
+const {query, db} = require("@arangodb");
+const request = require("@arangodb/request");
+const {context} = require("@arangodb/locals");
 
 const {argv} = module.context;
 
 const {batchIndex, batchSize, collectionName, modelMetadata, fieldName} = argv[0];
 
+function getDocumentsToEmbed(nDocs, startInd, collection, fieldToEmbed) {
+    const start_index = startInd * nDocs;
+
+    const toEmbed = query`
+    FOR doc in ${collection}
+        FILTER doc.${fieldToEmbed} != null
+        LIMIT ${start_index}, ${nDocs}
+        RETURN {
+          "_key": doc._key,
+          "field": doc.${fieldToEmbed}
+        }
+    `.toArray();
+    return toEmbed;
+}
+
+function formatBatch(batchData) {
+    return {
+        inputs: [
+            {
+                name: "INPUT0",
+                data: batchData,
+                shape: [batchData.length],
+                datatype: "BYTES"
+            }
+        ]
+    }
+}
+
+function invokeEmbeddingModel(dataToEmbed) {
+    const embeddingsServiceUrl = `${context.configuration.embeddingService}/v2/models/${modelMetadata.invocation_name}/infer`;
+    const res = request.post(embeddingsServiceUrl, {
+        body: formatBatch(dataToEmbed),
+        json: true
+    });
+    return res;
+}
+
+function chunkArray(array, chunk_size) {
+    return Array(Math.ceil(array.length / chunk_size))
+        .fill()
+        .map((_, i) => i * chunk_size)
+        .map(begin => array.slice(begin, begin + chunk_size));
+}
+
+function extractEmbeddingsFromResponse(response_json, embedding_dim) {
+    // TODO: this is brittle, outputs may differ per model
+    const output = JSON.parse(response_json);
+    const giant_arr = output["outputs"][0]["data"];
+    return chunkArray(giant_arr, embedding_dim);
+}
+
+function insertEmbeddingsIntoDBSameCollection(docsWithKey, calculatedEmbeddings, collection, modelMetadata) {
+    const docs = docsWithKey.map((x, i) => {
+        return { "_key": x["_key"], "embedding": calculatedEmbeddings[i] };
+    });
+
+    const embedding_field_name = `emb_${modelMetadata.name}`
+
+    query`
+    FOR doc in ${docs}
+      UPDATE {
+        _key: doc["_key"]
+      } WITH {
+        ${embedding_field_name}: doc["embedding"]
+      } IN ${collection}
+    `
+}
+
+
+// Actual processing done here
 console.log(`Create embeddings for batch ${batchIndex} of size ${batchSize} in collection ${collectionName} using ${modelMetadata.name} on the ${fieldName} field`);
+const collection = db._collection(collectionName)
+const toEmbed = getDocumentsToEmbed(batchSize, batchIndex, collection, fieldName);
+const requestData = toEmbed.map(x => x["field"]);
+const res = invokeEmbeddingModel(requestData);
+const embeddings = extractEmbeddingsFromResponse(res.body, modelMetadata.metadata.emb_dim);
+insertEmbeddingsIntoDBSameCollection(toEmbed, embeddings, collection, modelMetadata);

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -2,6 +2,7 @@
 
 const db = require("@arangodb").db;
 const {modelTypes, metadataCollectionName, modelMetadataSchema} = require("../model/model_metadata");
+const {embeddingsStatusCollectionName, embeddingsStatusSchema}  = require("../model/embeddings_status");
 
 
 function createModelMetadataCollection() {
@@ -9,6 +10,13 @@ function createModelMetadataCollection() {
         db._createDocumentCollection(metadataCollectionName, { "schema": modelMetadataSchema });
     }
     return db._collection(metadataCollectionName);
+}
+
+function createEmbeddingsStatusCollection() {
+    if (!db._collection(embeddingsStatusCollectionName)) {
+        db._createDocumentCollection(embeddingsStatusCollectionName, { "schema": embeddingsStatusSchema });
+    }
+    return db._collection(embeddingsStatusCollectionName);
 }
 
 const seedData = [
@@ -94,3 +102,4 @@ function seedMetadataCol(collection) {
 
 const modelMetadataCol = createModelMetadataCollection();
 seedMetadataCol(modelMetadataCol);
+createEmbeddingsStatusCollection();

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -14,30 +14,31 @@ function createModelMetadataCollection() {
 const seedData = [
     {
         model_type: modelTypes.WORD_EMBEDDING,
-        name: "distilbert-base-uncased",
-        _key: "distilbert-base-uncased",
+        name: "paraphrase-mpnet-base-v2",
+        _key: "paraphrase-mpnet-base-v2",
         framework: {
             name: "pytorch",
             version: "1.9.0"
         },
-        website: "https://huggingface.co/distilbert-base-uncased",
+        website: "https://www.sbert.net/docs/pretrained_models.html",
         // This is the name that this model will have on the compute node. May differ from display name
-        invocation_name: "distilbert-base-uncased",
+        invocation_name: "word_embeddings",
         data: [ // A list of the datasets that were used during training
             // modification of the MLSpec - MLSpec has a single data source specified
-            {
-                source_id: "BOOK-CORPUS",
-                domain: "text",
-                website: "https://yknzhu.wixsite.com/mbweb"
-            },
-            {
-                source_id: "EN-Wikipedia",
-                domain: "text",
-                website: "https://en.wikipedia.org/wiki/English_Wikipedia"
-            }
+            // {
+            //     source_id: "BOOK-CORPUS",
+            //     domain: "text",
+            //     website: "https://yknzhu.wixsite.com/mbweb"
+            // },
+            // {
+            //     source_id: "EN-Wikipedia",
+            //     domain: "text",
+            //     website: "https://en.wikipedia.org/wiki/English_Wikipedia"
+            // }
         ],
         metadata: {
             emb_dim: 768,
+            inference_batch_size: 64,
             schema: {
                 type: "RAW/TEXT",
             }
@@ -70,6 +71,7 @@ const seedData = [
         },
         metadata: {
             emb_dim: 256,
+            inference_batch_size: 64,
             schema: {
                 features: ["bag_of_words"],
                 type: "NUMERIC",

--- a/services/emb_collections_service.js
+++ b/services/emb_collections_service.js
@@ -23,4 +23,9 @@ function getDestinationCollectionName(collectionName, separateCollection, modelM
     return colName;
 }
 
+function getEmbeddingsFieldName(fieldName, modelMetadata) {
+    return `emb_${modelMetadata.name}_${fieldName}`;
+}
+
 exports.getDestinationCollectionName = getDestinationCollectionName;
+exports.getEmbeddingsFieldName = getEmbeddingsFieldName;

--- a/services/emb_collections_service.js
+++ b/services/emb_collections_service.js
@@ -2,7 +2,7 @@
 
 const {query, db} = require("@arangodb");
 
-function nameForCollectionAndModel(collectionName, modelName) {
+function colNameForCollectionAndModel(collectionName, modelName) {
     return `emb_${collectionName}_${modelName}`;
 }
 
@@ -12,7 +12,7 @@ function getDestinationCollectionName(collectionName, separateCollection, modelM
         return collectionName;
     }
     // Otherwise create the separate collection name
-    const colName = nameForCollectionAndModel(collectionName, modelMetadata.name);
+    const colName = colNameForCollectionAndModel(collectionName, modelMetadata.name);
 
     // And create it if it doesn't already exist
     if (!db._collection(colName)) {

--- a/services/emb_collections_service.js
+++ b/services/emb_collections_service.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const {db} = require("@arangodb");
+const {query, db} = require("@arangodb");
 
 function nameForCollectionAndModel(collectionName, modelName) {
     return `emb_${collectionName}_${modelName}`;
@@ -27,5 +27,16 @@ function getEmbeddingsFieldName(fieldName, modelMetadata) {
     return `emb_${modelMetadata.name}_${fieldName}`;
 }
 
+function deleteEmbeddingsFieldEntries(destinationCollectionName, sourceFieldName, modelMetadata) {
+    const dCol = db._collection(destinationCollectionName);
+    const embedding_field_name = getEmbeddingsFieldName(sourceFieldName, modelMetadata);
+    query`
+    FOR doc in ${dCol}
+      FILTER doc[${embedding_field_name}] != null
+      UPDATE doc WITH { ${embedding_field_name}: null } IN ${dCol} OPTIONS { keepNull: false }
+    `;
+}
+
 exports.getDestinationCollectionName = getDestinationCollectionName;
 exports.getEmbeddingsFieldName = getEmbeddingsFieldName;
+exports.deleteEmbeddingsFieldEntries = deleteEmbeddingsFieldEntries;

--- a/services/emb_collections_service.js
+++ b/services/emb_collections_service.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const {db} = require("@arangodb");
+
+function nameForCollectionAndModel(collectionName, modelName) {
+    return `emb_${collectionName}_${modelName}`;
+}
+
+function getDestinationCollectionName(collectionName, separateCollection, modelMetadata) {
+    // If not a separate collection, store on documents
+    if (!separateCollection) {
+        return collectionName;
+    }
+    // Otherwise create the separate collection name
+    const colName = nameForCollectionAndModel(collectionName, modelMetadata.name);
+
+    // And create it if it doesn't already exist
+    if (!db._collection(colName)) {
+        db._createDocumentCollection(colName);
+    }
+
+    // Then return it
+    return colName;
+}
+
+exports.getDestinationCollectionName = getDestinationCollectionName;

--- a/services/emb_generation_service.js
+++ b/services/emb_generation_service.js
@@ -7,16 +7,22 @@ const {query, db} = require("@arangodb");
 
 const embeddingQueueName = "embeddings_generation";
 
-function queueCollectionBatch(i, batchSize, colName, fieldName, modelMetadata, embeddingsQueue, destinationCollection, separateCollection, isLastBatch) {
+const scripts = {
+    NODE: "createNodeEmbeddings",
+    GRAPH: "createGraphEmbeddings"
+};
+
+function queueBatch(scriptName, i, batchSize, graphName, colName, fieldName, modelMetadata, embeddingsQueue, destinationCollection, separateCollection, isLastBatch) {
     embeddingsQueue.push(
         {
             mount: context.mount,
-            name: "createNodeEmbeddings"
+            name: scriptName
         },
         {
             collectionName: colName,
             batchIndex: i,
             modelMetadata,
+            graphName,
             fieldName,
             batchSize,
             destinationCollection,
@@ -26,59 +32,11 @@ function queueCollectionBatch(i, batchSize, colName, fieldName, modelMetadata, e
     );
 }
 
-function queueGraphBatch(i, batchSize, colName, graphName, fieldName, modelMetadata, embeddingsQueue, destinationCollection, separateCollection) {
-    embeddingsQueue.push(
-        {
-            mount: context.mount,
-            name: "createGraphEmbeddings"
-        },
-        {
-            collectionName: colName,
-            batchIndex: i,
-            graphName,
-            modelMetadata,
-            fieldName,
-            batchSize,
-            destinationCollection,
-            separateCollection
-        }
-    );
-}
-
 /**
- * Queue batch jobs to generate embeddings for a specified collection.
+ * Queue batch jobs to generate embeddings for a specified model/scriptType.
  * Returns true if batch jobs have been queued. This does NOT mean that they've succeeded yet.
  */
-function generateBatchesCollection(colName, fieldName, destinationCollection, separateCollection, modelMetadata) {
-    const myCol = db._collection(colName);
-    const numberOfDocuments = query`
-    RETURN COUNT(
-        FOR doc in ${myCol}
-        FILTER doc.${fieldName} != null
-        RETURN 1
-    )
-    `.toArray();
-
-    const batch_size = modelMetadata.metadata.inference_batch_size;
-    const numBatches = Math.ceil(numberOfDocuments / batch_size);
-
-    const embQ = queues.create(embeddingQueueName);
-
-    Array(numBatches)
-        .fill()
-        .map((_, i) => i)
-        .forEach(i => queueCollectionBatch(
-            i, batch_size, colName, fieldName, modelMetadata, embQ, destinationCollection, separateCollection, i == (numBatches - 1)
-        ));
-
-    return true;
-}
-
-/**
- * Queue batch jobs to generate embeddings for a specified graph.
- * Returns true if batch jobs have been queued. This does NOT mean that they've succeeded yet.
- */
-function generateBatchesGraph(graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata) {
+function generateBatches(scriptType, graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata) {
     const myCol = db._collection(collectionName);
     const numberOfDocuments = query`
     RETURN COUNT(
@@ -96,35 +54,38 @@ function generateBatchesGraph(graphName, collectionName, fieldName, destinationC
     Array(numBatches)
         .fill()
         .map((_, i) => i)
-        .forEach(i => queueGraphBatch(
-            i, batch_size, collectionName, graphName, fieldName, modelMetadata, embQ, destinationCollection, separateCollection
+        .forEach(i => queueBatch(
+            scriptType,
+            i,
+            batch_size,
+            collectionName,
+            graphName,
+            fieldName,
+            modelMetadata,
+            embQ,
+            destinationCollection,
+            separateCollection,
+            i === (numBatches - 1)
         ));
-
-    return true;
 }
 
 function generateBatchesForModel(graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata) {
     switch (modelMetadata.model_type) {
         case modelTypes.WORD_EMBEDDING: {
-            const isQueued = generateBatchesCollection(collectionName, fieldName, destinationCollection, separateCollection, modelMetadata);
-            if (isQueued) {
-                return `Queued generation of embeddings for collection ${collectionName} using ${modelMetadata.name} on the ${fieldName} field`;
-            }
-            break;
+            generateBatches(scripts.NODE, graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata);
+            return true;
         }
         case modelTypes.GRAPH_MODEL: {
             if (!graphName) {
                 throw new Error("Requested to generate graph embeddings but no graph is provided");
             }
-            const isQueued = generateBatchesGraph(graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata);
-            if (isQueued) {
-                return `Queued generation of embeddings for collection ${collectionName} traversing ${graphName} using ${modelMetadata.name} on the ${fieldName} field`;
-            }
-            break;
+            generateBatches(scripts.GRAPH, graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata);
+            return true;
         }
         default:
             throw new Error(`Error: unrecognized model type: ${modelMetadata.model_type}`);
     }
+    throw new Error("Unable to queue batches.");
 }
 
 exports.generateBatchesForModel = generateBatchesForModel;

--- a/services/emb_generation_service.js
+++ b/services/emb_generation_service.js
@@ -7,7 +7,7 @@ const {query, db} = require("@arangodb");
 
 const embeddingQueueName = "embeddings_generation";
 
-function queueCollectionBatch(i, batchSize, colName, fieldName, modelMetadata, embeddingsQueue, destinationCollection, separateCollection) {
+function queueCollectionBatch(i, batchSize, colName, fieldName, modelMetadata, embeddingsQueue, destinationCollection, separateCollection, isLastBatch) {
     embeddingsQueue.push(
         {
             mount: context.mount,
@@ -20,7 +20,8 @@ function queueCollectionBatch(i, batchSize, colName, fieldName, modelMetadata, e
             fieldName,
             batchSize,
             destinationCollection,
-            separateCollection
+            separateCollection,
+            isLastBatch
         }
     );
 }
@@ -67,7 +68,7 @@ function generateBatchesCollection(colName, fieldName, destinationCollection, se
         .fill()
         .map((_, i) => i)
         .forEach(i => queueCollectionBatch(
-            i, batch_size, colName, fieldName, modelMetadata, embQ, destinationCollection, separateCollection
+            i, batch_size, colName, fieldName, modelMetadata, embQ, destinationCollection, separateCollection, i == (batch_size - 1)
         ));
 
     return true;

--- a/services/emb_generation_service.js
+++ b/services/emb_generation_service.js
@@ -68,7 +68,7 @@ function generateBatchesCollection(colName, fieldName, destinationCollection, se
         .fill()
         .map((_, i) => i)
         .forEach(i => queueCollectionBatch(
-            i, batch_size, colName, fieldName, modelMetadata, embQ, destinationCollection, separateCollection, i == (batch_size - 1)
+            i, batch_size, colName, fieldName, modelMetadata, embQ, destinationCollection, separateCollection, i == (numBatches - 1)
         ));
 
     return true;

--- a/services/emb_generation_service.js
+++ b/services/emb_generation_service.js
@@ -21,13 +21,13 @@ function queueBatch(scriptName, i, batchSize, graphName, colName, fieldName, mod
         {
             collectionName: colName,
             batchIndex: i,
-            modelMetadata,
-            graphName,
-            fieldName,
-            batchSize,
-            destinationCollection,
-            separateCollection,
-            isLastBatch
+            modelMetadata: modelMetadata,
+            graphName: graphName,
+            fieldName: fieldName,
+            batchSize: batchSize,
+            destinationCollection: destinationCollection,
+            separateCollection: separateCollection,
+            isLastBatch: isLastBatch
         }
     );
 }
@@ -58,8 +58,8 @@ function generateBatches(scriptType, graphName, collectionName, fieldName, desti
             scriptType,
             i,
             batch_size,
-            collectionName,
             graphName,
+            collectionName,
             fieldName,
             modelMetadata,
             embQ,
@@ -85,7 +85,6 @@ function generateBatchesForModel(graphName, collectionName, fieldName, destinati
         default:
             throw new Error(`Error: unrecognized model type: ${modelMetadata.model_type}`);
     }
-    throw new Error("Unable to queue batches.");
 }
 
 exports.generateBatchesForModel = generateBatchesForModel;

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -2,9 +2,8 @@
 const {updateStatusByCollectionDestinationAndEmbName} = require("../db/embeddings_status");
 const {createStatus} = require("../db/embeddings_status");
 const {getStatusesByCollectionDestinationAndEmbName} = require("../db/embeddings_status");
-const {query, db} = require("@arangodb");
 const {getEmbeddingsFieldName} = require("./emb_collections_service");
-const {embeddingsStatusCollectionName, embeddingsStatus} = require("../model/embeddings_status");
+const {embeddingsStatus} = require("../model/embeddings_status");
 
 /**
  * Get the status of how the embeddings generation is going.

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -10,7 +10,7 @@ const {embeddingsStatus} = require("../model/embeddings_status");
  */
 function getEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata) {
     const res = getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, getEmbeddingsFieldName(fieldName, modelMetadata))
-    if (res.length == 0) {
+    if (res.length === 0) {
         return embeddingsStatus.DOES_NOT_EXIST;
     }
     return res[0]["status"];
@@ -21,7 +21,7 @@ function getEmbeddingsStatus(collectionName, destinationCollectionName, fieldNam
  */
 function getEmbeddingsStatusDocId(collectionName, destinationCollectionName, fieldName, modelMetadata) {
     const res = getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, getEmbeddingsFieldName(fieldName, modelMetadata))
-    if (res.length == 0) {
+    if (res.length === 0) {
         return null;
     }
     return res[0]["_key"];

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -42,11 +42,11 @@ function createEmbeddingsStatus(collectionName, destinationCollectionName, field
 function updateEmbeddingsStatus(newStatus, collectionName, destinationCollectionName, fieldName, modelMetadata) {
     const col = db._collection(embeddingsStatusCollectionName);
     query`
-      FOR d in ${col}
+    FOR d in ${col}
         FILTER d.collection == ${collectionName}
         AND d.destination_collection == ${destinationCollectionName}
         AND d.emb_field_name == ${getEmbeddingsFieldName(fieldName, modelMetadata)}
-        UPDATE { _key: d._key, status: ${newStatus} } IN ${col}
+        UPDATE d._key WITH { status: ${newStatus} } IN ${col}
     `;
 }
 exports.getEmbeddingsStatus = getEmbeddingsStatus;

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -1,0 +1,54 @@
+"use strict";
+const {query, db} = require("@arangodb");
+const {getEmbeddingsFieldName} = require("./emb_collections_service");
+const {embeddingsStatusCollectionName, embeddingsStatus} = require("../model/embeddings_status");
+
+/**
+ * Get the status of how the embeddings generation is going.
+ */
+function getEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    const res = query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.destination_collection == ${destinationCollectionName}
+        AND d.emb_field_name == ${getEmbeddingsFieldName(fieldName, modelMetadata)}
+        RETURN d
+    `.toArray();
+    if (res.length == 0) {
+        return embeddingsStatus.DOES_NOT_EXIST;
+    }
+    return res[0]["status"];
+}
+
+/**
+ * Create a new status of how the embeddings generation is going.
+ */
+function createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    query`
+    INSERT {
+        collection: ${collectionName},
+        destination_collection: ${destinationCollectionName},
+        emb_field_name: ${getEmbeddingsFieldName(fieldName, modelMetadata)},
+        status: ${embeddingsStatus.RUNNING}
+    } INTO ${col}
+    `;
+}
+
+/**
+ * Update the status of how the embeddings generation is going.
+ */
+function updateEmbeddingsStatus(newStatus, collectionName, destinationCollectionName, fieldName, modelMetadata) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    query`
+      FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.destination_collection == ${destinationCollectionName}
+        AND d.emb_field_name == ${getEmbeddingsFieldName(fieldName, modelMetadata)}
+        UPDATE { _key: d._key, status: ${newStatus} } IN ${col}
+    `;
+}
+exports.getEmbeddingsStatus = getEmbeddingsStatus;
+exports.createEmbeddingsStatus = createEmbeddingsStatus;
+exports.updateEmbeddingsStatus = updateEmbeddingsStatus;

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -22,6 +22,23 @@ function getEmbeddingsStatus(collectionName, destinationCollectionName, fieldNam
 }
 
 /**
+ * Get the document ID of an embedding status. Returns `null` if not found.
+ */
+function getEmbeddingsStatusDocId(collectionName, destinationCollectionName, fieldName, modelMetadata) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    const res = query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.destination_collection == ${destinationCollectionName}
+        AND d.emb_field_name == ${getEmbeddingsFieldName(fieldName, modelMetadata)}
+        RETURN d
+    `.toArray();
+    if (res.length == 0) {
+        return null;
+    }
+    return res[0]["_key"];
+}
+/**
  * Create a new status of how the embeddings generation is going.
  */
 function createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata) {
@@ -50,5 +67,6 @@ function updateEmbeddingsStatus(newStatus, collectionName, destinationCollection
     `;
 }
 exports.getEmbeddingsStatus = getEmbeddingsStatus;
+exports.getEmbeddingsStatusDocId = getEmbeddingsStatusDocId;
 exports.createEmbeddingsStatus = createEmbeddingsStatus;
 exports.updateEmbeddingsStatus = updateEmbeddingsStatus;

--- a/services/embeddings_service.js
+++ b/services/embeddings_service.js
@@ -5,8 +5,6 @@ const queues = require("@arangodb/foxx/queues");
 const {modelTypes} = require("../model/model_metadata");
 const {query, db} = require("@arangodb");
 
-// TODO: Make this model specific?
-const batch_size = 64;
 const embeddingQueueName = "embeddings_generation";
 
 function queueCollectionBatch(i, batchSize, colName, fieldName, modelMetadata, embeddingsQueue) {
@@ -56,6 +54,7 @@ function generateBatchesCollection(colName, fieldName, modelMetadata) {
     )
     `.toArray();
 
+    const batch_size = modelMetadata.metadata.inference_batch_size;
     const numBatches = Math.ceil(numberOfDocuments / batch_size);
 
     const embQ = queues.create(embeddingQueueName);
@@ -82,6 +81,7 @@ function generateBatchesGraph(graphName, collectionName, fieldName, modelMetadat
     )
     `.toArray();
 
+    const batch_size = modelMetadata.metadata.inference_batch_size;
     const numBatches = Math.ceil(numberOfDocuments / batch_size);
 
     const embQ = queues.create(embeddingQueueName);
@@ -118,5 +118,4 @@ function generateBatchesForModel(graphName, collectionName, fieldName, modelMeta
     }
 }
 
-exports.BATCH_SIZE = batch_size;
 exports.generateBatchesForModel = generateBatchesForModel;

--- a/utils/db.js
+++ b/utils/db.js
@@ -1,0 +1,17 @@
+/**
+ * This module contains database interaction utilities
+ */
+"use strict";
+const {db} = require("@arangodb");
+const graph_module = require("@arangodb/general-graph");
+
+function checkGraphIsPresent(graphName) {
+    return graph_module._list().some(g => g === graphName)
+}
+
+function checkCollectionIsPresent(collectionName) {
+    return db._collections().map(c => c.name()).some(n => n === collectionName)
+}
+
+exports.checkGraphIsPresent = checkGraphIsPresent;
+exports.checkCollectionIsPresent = checkCollectionIsPresent;


### PR DESCRIPTION
This PR:
- Adds an embeddings progress status collection to monitor the progress of embeddings generation (see `models/embeddings_status.js`, `services/emb_collections_service.js`, `db/embeddings_status.js`
- Refactors batch queuing logic (was in `services/embeddings_service.js`, has been renamed to `services/emb_generation_service`)
- Adds embeddings generation job contents - to actually generate embeddings, using and external Triton server compute service (https://github.com/arangoml/embeddings-compute).
- Updates the embeddings generation endpoint to not automatically queue new generation jobs, if the embeddings already exist, or if a batch job is already running
- Adds endpoints to query the status of embeddings jobs (`/embeddings_status?` and `/embeddings_status/:myIdHere`)