### PR TITLE
Resume and update functionality

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -4,6 +4,7 @@ const createRouter = require("@arangodb/foxx/router");
 const joi = require("joi");
 const {listModels} = require("../controllers/list_models");
 const {generateEmbeddings} = require("../controllers/generate_embeddings");
+const {embeddingsStatusesForModel, embeddingsStatusById} = require("../controllers/embeddings_status");
 const {modelTypes} = require("../model/model_metadata");
 
 const router = createRouter();
@@ -54,6 +55,41 @@ router.post("/generate_embeddings", generateEmbeddings)
         joi.object({
             message: joi.string(),
             embeddings_status_id: joi.string()
+        })
+    );
+
+router.get("/embeddings_status/:statusId", embeddingsStatusById)
+    .pathParam("statusId", joi.string().required(), "ID of embeddings generation status")
+    .response(
+        404,
+        joi.string(),
+        "Not found"
+    )
+    .response(200,
+        joi.object({
+            status: joi.string(),
+            documentCollection: joi.string(),
+            embeddingsCollection: joi.string(),
+            embeddingsFieldName: joi.string()
+        })
+    );
+
+router.get("/embeddings_status", embeddingsStatusesForModel)
+    .queryParam("modelName", joi.string().required())
+    .queryParam("modelType", joi.string().required())
+    .queryParam("collectionName", joi.string().required())
+    .queryParam("fieldName", joi.string().required())
+    .response(
+        404,
+        joi.string(),
+        "Not found"
+    )
+    .response(200,
+        joi.object({
+            status: joi.string(),
+            documentCollection: joi.string(),
+            embeddingsCollection: joi.string(),
+            embeddingsFieldName: joi.string()
         })
     );
 

--- a/api/router.js
+++ b/api/router.js
@@ -50,7 +50,12 @@ router.post("/generate_embeddings", generateEmbeddings)
         422,
         joi.string(),
         "Invalid input"
-    ).response(200, joi.string());
+    ).response(200,
+        joi.object({
+            message: joi.string(),
+            embeddings_status_id: joi.string()
+        })
+    );
 
 router.get("/models", listModels)
     .response(

--- a/api/router.js
+++ b/api/router.js
@@ -19,7 +19,8 @@ router.post("/generate_embeddings", generateEmbeddings)
             // then pick field
             // (for graph embeddings this is a set of features, for word embeddings this is a text field)
             fieldName: joi.string().required(),
-            separateCollection: joi.bool().default(true)
+            separateCollection: joi.bool().default(true),
+            overwriteExisting: joi.bool().default(false),
         }).required(),
         // This seems to be encased in a "value" object in the swagger doc
         // .example([{
@@ -39,6 +40,8 @@ router.post("/generate_embeddings", generateEmbeddings)
          \`fieldName\`: name of the field to embed. For graph embeddings this is a feature vector, for word embeddings this is a string.
          \`separateCollection\`: whether or not to store embeddings in a separate collection - \`true\` by default. If set to false, the embeddings
          \twill be stored on the documents in the specified collection.
+         \`overwriteExisting\`: \`false\` by default. If set to \`true\` then this will overwrite existing embeddings for the collection+field+model combination
+         \t if it exists.
          `
     ).response(
         400,

--- a/controllers/embeddings_status.js
+++ b/controllers/embeddings_status.js
@@ -1,3 +1,4 @@
+"use strict";
 const {getStatusByKey} = require("../db/embeddings_status");
 const {getStatusesByCollectionAndEmbName} = require("../db/embeddings_status");
 const {retrieveModel} = require("../services/model_metadata_service");
@@ -18,7 +19,7 @@ function embeddingsStatusesForModel(req, res) {
         getEmbeddingsFieldName(fieldName, modelMetadata)
     );
 
-    if (statuses.length == 0) {
+    if (statuses.length === 0) {
         res.throw(404, "Status not found");
     }
     res.json(statuses);

--- a/controllers/embeddings_status.js
+++ b/controllers/embeddings_status.js
@@ -1,0 +1,45 @@
+const {query, db} = require("@arangodb");
+const {embeddingsStatusCollectionName} = require("../model/embeddings_status");
+const {retrieveModel} = require("../services/model_metadata_service");
+const {getEmbeddingsFieldName} = require("../services/emb_collections_service");
+const {sendInvalidInputMessage} = require("../utils/invalid_input");
+
+function embeddingsStatusesForModel(req, res) {
+    const {modelName, modelType, collectionName, fieldName} = req.queryParams;
+    const modelMetadata = retrieveModel(modelName, modelType);
+
+    if (modelMetadata == null) {
+        sendInvalidInputMessage(res,
+            `Invalid model: ${modelName} of type ${modelType}`);
+    }
+
+    const col = db._collection(embeddingsStatusCollectionName);
+    const statuses = query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.emb_field_name == ${getEmbeddingsFieldName(fieldName, modelMetadata)}
+        RETURN d
+    `.toArray();
+    if (statuses.length == 0) {
+        res.throw(404, "Status not found");
+    }
+    res.json(statuses);
+}
+
+function embeddingsStatusById(req, res) {
+    const {statusId} = req.pathParams;
+
+    const col = db._collection(embeddingsStatusCollectionName);
+    const statuses = query`
+    FOR d in ${col}
+        FILTER d._key == ${statusId}
+        RETURN d
+    `.toArray();
+    if (statuses.length == 0) {
+        res.throw(404, "Status not found");
+    }
+    res.json(statuses[0]);
+}
+
+exports.embeddingsStatusesForModel = embeddingsStatusesForModel;
+exports.embeddingsStatusById = embeddingsStatusById;

--- a/controllers/embeddings_status.js
+++ b/controllers/embeddings_status.js
@@ -1,5 +1,5 @@
-const {query, db} = require("@arangodb");
-const {embeddingsStatusCollectionName} = require("../model/embeddings_status");
+const {getStatusByKey} = require("../db/embeddings_status");
+const {getStatusesByCollectionAndEmbName} = require("../db/embeddings_status");
 const {retrieveModel} = require("../services/model_metadata_service");
 const {getEmbeddingsFieldName} = require("../services/emb_collections_service");
 const {sendInvalidInputMessage} = require("../utils/invalid_input");
@@ -13,13 +13,11 @@ function embeddingsStatusesForModel(req, res) {
             `Invalid model: ${modelName} of type ${modelType}`);
     }
 
-    const col = db._collection(embeddingsStatusCollectionName);
-    const statuses = query`
-    FOR d in ${col}
-        FILTER d.collection == ${collectionName}
-        AND d.emb_field_name == ${getEmbeddingsFieldName(fieldName, modelMetadata)}
-        RETURN d
-    `.toArray();
+    const statuses = getStatusesByCollectionAndEmbName(
+        collectionName,
+        getEmbeddingsFieldName(fieldName, modelMetadata)
+    );
+
     if (statuses.length == 0) {
         res.throw(404, "Status not found");
     }
@@ -29,16 +27,11 @@ function embeddingsStatusesForModel(req, res) {
 function embeddingsStatusById(req, res) {
     const {statusId} = req.pathParams;
 
-    const col = db._collection(embeddingsStatusCollectionName);
-    const statuses = query`
-    FOR d in ${col}
-        FILTER d._key == ${statusId}
-        RETURN d
-    `.toArray();
-    if (statuses.length == 0) {
+    const status = getStatusByKey(statusId);
+    if (status == null) {
         res.throw(404, "Status not found");
     }
-    res.json(statuses[0]);
+    res.json(status);
 }
 
 exports.embeddingsStatusesForModel = embeddingsStatusesForModel;

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const {db} = require("@arangodb");
-const graph_module = require("@arangodb/general-graph");
+const {checkCollectionIsPresent, checkGraphIsPresent} = require("../utils/db");
 const {updateEmbeddingsStatus} = require("../services/emb_status_service");
 const {modelTypes} = require("../model/model_metadata");
 const {embeddingsStatus} = require("../model/embeddings_status");
@@ -30,13 +29,6 @@ function initialValidationGenerateEmbParams(req, res) {
     }
 }
 
-function checkGraphIsPresent(graphName) {
-    return graph_module._list().some(g => g === graphName)
-}
-
-function checkCollectionIsPresent(collectionName) {
-    return db._collections().map(c => c.name()).some(n => n === collectionName)
-}
 
 function handleGenerationForModel(embStatus, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata, overwriteExisting) {
     let response_dict = {};

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -9,6 +9,7 @@ const {retrieveModel} = require("../services/model_metadata_service");
 const {getEmbeddingsStatus, createEmbeddingsStatus, getEmbeddingsStatusDocId} = require("../services/emb_status_service");
 const {generateBatchesForModel} = require("../services/emb_generation_service");
 const {getDestinationCollectionName} = require("../services/emb_collections_service");
+const {profileCall} = require("../utils/profiling");
 
 function initialValidationGenerateEmbParams(req, res) {
     // check if model type is valid
@@ -90,9 +91,9 @@ function generateEmbeddings(req, res) {
             `Invalid model: ${modelName} of type ${modelType}`);
     }
 
-    const destinationCollectionName = getDestinationCollectionName(collectionName, separateCollection, modelMetadata);
-    const embStatus = getEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata);
-    const response_dict = handleGenerationForModel(embStatus, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata, overwriteExisting);
+    const destinationCollectionName = profileCall(getDestinationCollectionName)(collectionName, separateCollection, modelMetadata);
+    const embStatus = profileCall(getEmbeddingsStatus)(collectionName, destinationCollectionName, fieldName, modelMetadata);
+    const response_dict = profileCall(handleGenerationForModel)(embStatus, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata, overwriteExisting);
     res.json(response_dict);
 }
 

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -61,11 +61,12 @@ function handleGenerationForModel(embStatus, graphName, collectionName, fieldNam
         case embeddingsStatus.COMPLETED:
             // Overwrite by default
             if (!overwriteExisting) {
-                return "These embeddings have already been generated!";
-            }
-            updateEmbeddingsStatus(embeddingsStatus.RUNNING, collectionName, destinationCollectionName, fieldName, modelMetadata);
-            if (generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata)) {
-                response_dict["message"] = "Overwriting old embeddings. " + start_msg;
+                response_dict["message"] = "These embeddings have already been generated!";
+            } else {
+                updateEmbeddingsStatus(embeddingsStatus.RUNNING, collectionName, destinationCollectionName, fieldName, modelMetadata);
+                if (generateBatchesForModel(graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata)) {
+                    response_dict["message"] = "Overwriting old embeddings. " + start_msg;
+                }
             }
             break;
     }

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -1,3 +1,6 @@
+/**
+ * This module is responsible for queries interacting with the Embeddings status metadata collection
+ */
 "use strict";
 const {query, db} = require("@arangodb");
 const {embeddingsStatusCollectionName} = require("../model/embeddings_status");
@@ -26,5 +29,43 @@ function getStatusesByCollectionAndEmbName(collectionName, embeddingsFieldName) 
     return statuses;
 }
 
+function getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, embeddingsFieldName) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    const res = query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.destination_collection == ${destinationCollectionName}
+        AND d.emb_field_name == ${embeddingsFieldName}
+        RETURN d
+    `.toArray();
+    return res;
+}
+
+function createStatus(collectionName, destinationCollectionName, embeddingsFieldName, status) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    query`
+    INSERT {
+        collection: ${collectionName},
+        destination_collection: ${destinationCollectionName},
+        emb_field_name: ${embeddingsFieldName},
+        status: ${status}
+    } INTO ${col}
+    `;
+}
+
+function updateStatusByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, embeddingsFieldName, newStatus) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.destination_collection == ${destinationCollectionName}
+        AND d.emb_field_name == ${embeddingsFieldName}
+        UPDATE d._key WITH { status: ${newStatus} } IN ${col}
+    `;
+}
+
 exports.getStatusByKey = getStatusByKey;
 exports.getStatusesByCollectionAndEmbName = getStatusesByCollectionAndEmbName;
+exports.getStatusesByCollectionDestinationAndEmbName = getStatusesByCollectionDestinationAndEmbName;
+exports.createStatus = createStatus;
+exports.updateStatusByCollectionDestinationAndEmbName = updateStatusByCollectionDestinationAndEmbName;

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -1,0 +1,30 @@
+"use strict";
+const {query, db} = require("@arangodb");
+const {embeddingsStatusCollectionName} = require("../model/embeddings_status");
+
+function getStatusByKey(key) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    const statuses = query`
+    FOR d in ${col}
+        FILTER d._key == ${key}
+        RETURN d
+    `.toArray();
+    if (statuses.length == 0) {
+        return null;
+    }
+    return statuses[0];
+}
+
+function getStatusesByCollectionAndEmbName(collectionName, embeddingsFieldName) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    const statuses = query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.emb_field_name == ${embeddingsFieldName}
+        RETURN d
+    `.toArray();
+    return statuses;
+}
+
+exports.getStatusByKey = getStatusByKey;
+exports.getStatusesByCollectionAndEmbName = getStatusesByCollectionAndEmbName;

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -41,15 +41,15 @@ function getStatusesByCollectionDestinationAndEmbName(collectionName, destinatio
 
 function createStatus(collectionName, destinationCollectionName, embeddingsFieldName, status, timestamp) {
     const col = db._collection(embeddingsStatusCollectionName);
-    query`
+    return query`
     INSERT {
         collection: ${collectionName},
         destination_collection: ${destinationCollectionName},
         emb_field_name: ${embeddingsFieldName},
         status: ${status},
         last_run_timestamp: ${timestamp}
-    } INTO ${col}
-    `;
+    } INTO ${col} RETURN NEW
+    `.toArray()[0];
 }
 
 function updateStatusByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, embeddingsFieldName, newStatus, timestamp) {

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -12,7 +12,7 @@ function getStatusByKey(key) {
         FILTER d._key == ${key}
         RETURN d
     `.toArray();
-    if (statuses.length == 0) {
+    if (statuses.length === 0) {
         return null;
     }
     return statuses[0];
@@ -20,25 +20,23 @@ function getStatusByKey(key) {
 
 function getStatusesByCollectionAndEmbName(collectionName, embeddingsFieldName) {
     const col = db._collection(embeddingsStatusCollectionName);
-    const statuses = query`
+    return query`
     FOR d in ${col}
         FILTER d.collection == ${collectionName}
         AND d.emb_field_name == ${embeddingsFieldName}
         RETURN d
     `.toArray();
-    return statuses;
 }
 
 function getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, embeddingsFieldName) {
     const col = db._collection(embeddingsStatusCollectionName);
-    const res = query`
+    return query`
     FOR d in ${col}
         FILTER d.collection == ${collectionName}
         AND d.destination_collection == ${destinationCollectionName}
         AND d.emb_field_name == ${embeddingsFieldName}
         RETURN d
     `.toArray();
-    return res;
 }
 
 function createStatus(collectionName, destinationCollectionName, embeddingsFieldName, status) {

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -14,7 +14,7 @@ const MAX_RETRIES = 5;
 function getDocumentsToEmbed(nDocs, startInd, collection, fieldToEmbed) {
     const start_index = startInd * nDocs;
 
-    const toEmbed = query`
+    return query`
     FOR doc in ${collection}
         FILTER doc.${fieldToEmbed} != null
         LIMIT ${start_index}, ${nDocs}
@@ -23,7 +23,6 @@ function getDocumentsToEmbed(nDocs, startInd, collection, fieldToEmbed) {
           "field": doc.${fieldToEmbed}
         }
     `.toArray();
-    return toEmbed;
 }
 
 function formatBatch(batchData) {
@@ -44,7 +43,7 @@ function invokeEmbeddingModel(dataToEmbed) {
     let tries = 0;
     let res = {"status": -1};
 
-    while (res.status != 200 && tries < MAX_RETRIES) {
+    while (res.status !== 200 && tries < MAX_RETRIES) {
         const now = new Date().getTime();
         while (new Date().getTime() < now + tries) {
             // NOP
@@ -130,7 +129,7 @@ function handleFailure(currentBatchFailed, isTheLastBatch, collectionName, desti
     }
 }
 
-if (getEmbeddingsStatus(collectionName, destinationCollection, fieldName, modelMetadata) == embeddingsStatus.RUNNING_FAILED) {
+if (getEmbeddingsStatus(collectionName, destinationCollection, fieldName, modelMetadata) === embeddingsStatus.RUNNING_FAILED) {
     console.log(`Generation failed, skipping batch ${batchIndex}`);
     handleFailure(false, isLastBatch, collectionName, destinationCollection, fieldName, modelMetadata);
 } else {
@@ -142,7 +141,7 @@ if (getEmbeddingsStatus(collectionName, destinationCollection, fieldName, modelM
         const requestData = toEmbed.map(x => x["field"]);
         const res = invokeEmbeddingModel(requestData);
 
-        if (res.status == 200) {
+        if (res.status === 200) {
             const embeddings = extractEmbeddingsFromResponse(res.body, modelMetadata.metadata.emb_dim);
             if (separateCollection) {
                 const dCollection = db._collection(destinationCollection);

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -75,11 +75,11 @@ function extractEmbeddingsFromResponse(response_json, embedding_dim) {
 
 function logTimeElapsed(response_json) {
     const output = JSON.parse(response_json);
-    const time_resp = output["outputs"].find(e => e["name"] === "TIME_ELAPSED");
-    if (time_resp) {
-        const time_elapsed = time_resp["data"];
-        console.log(`Model call on compute node took ${time_elapsed} ms`);
-    }
+    output["outputs"]
+        .filter(e => e["name"].startsWith("TIME"))
+        .forEach(e => {
+            console.log(`Model call ${e["name"]} on compute node took ${e["data"]} ms`);
+        });
 }
 
 function insertEmbeddingsIntoDBSameCollection(docsWithKey, calculatedEmbeddings, fieldName, collection, modelMetadata) {

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -184,6 +184,7 @@ function createNodeEmbeddings() {
         const res = profileCall(invokeEmbeddingModel)(requestData);
 
         if (res.status === 200) {
+            logTimeElapsed(res.body);
             const embeddings = profileCall(extractEmbeddingsFromResponse)(res.body, modelMetadata.metadata.emb_dim);
             if (separateCollection) {
                 profileCall(insertEmbeddingsIntoDBSepCollection)(toEmbed, embeddings, fieldName, dCollection, modelMetadata);

--- a/services/emb_collections_service.js
+++ b/services/emb_collections_service.js
@@ -58,6 +58,7 @@ function getCountDocumentsSeparateCollection(embeddingsStatusDict, sourceFieldNa
     return query`
         RETURN COUNT(
             FOR doc in ${sCol}
+                FILTER doc.${sourceFieldName} != null
                 LET emb_docs = (
                     FOR emb_d in ${dCol}
                         FILTER emb_d.doc_key == doc._key
@@ -66,7 +67,6 @@ function getCountDocumentsSeparateCollection(embeddingsStatusDict, sourceFieldNa
                         RETURN 1
                 )  
                 FILTER LENGTH(emb_docs) == 0
-                FILTER doc.${sourceFieldName} != null
                 RETURN 1
         )
         `.toArray()[0];
@@ -80,7 +80,74 @@ function getCountDocumentsWithoutEmbedding(embeddingsStatusDict, sourceFieldName
     }
 }
 
+function embeddingsRunCollectionName(embeddingsStatusDict) {
+    return `docs_${embeddingsStatusDict["destination_collection"]}`;
+}
+
+function clearEmbeddingsRunCollection(embeddingsStatusDict) {
+    let colName = embeddingsRunCollectionName(embeddingsStatusDict);
+    let embeddingsRunCol = db._collection(colName);
+    if (embeddingsRunCol) {
+        embeddingsRunCol.drop();
+    }
+}
+
+function createEmbeddingsRunCollection(embeddingsStatusDict) {
+    let colName = embeddingsRunCollectionName(embeddingsStatusDict);
+    let embeddingsRunCol = db._collection(colName);
+    if (!embeddingsRunCol) {
+        embeddingsRunCol = db._createDocumentCollection(colName);
+    }
+    return embeddingsRunCol;
+}
+
+function createAndAddEmbeddingsRunCollectionSameCollection(embeddingsStatusDict, sourceFieldName) {
+    // Clear any docs first
+    clearEmbeddingsRunCollection(embeddingsStatusDict);
+    const embeddingsRunCol = createEmbeddingsRunCollection(embeddingsStatusDict);
+    const dCol = db._collection(embeddingsStatusDict["destination_collection"]);
+    const embedding_field_name = embeddingsStatusDict["emb_field_name"];
+    query`
+        FOR doc in ${dCol}
+          FILTER doc.${sourceFieldName} != null
+          FILTER doc.${embedding_field_name} == null
+          INSERT { _key: doc._key } INTO ${embeddingsRunCol}
+    `;
+}
+
+function createAndAddEmbeddingsRunCollectionSeparateCollection(embeddingsStatusDict, sourceFieldName) {
+    // Clear any docs first
+    clearEmbeddingsRunCollection(embeddingsStatusDict);
+    const embeddingsRunCol = createEmbeddingsRunCollection(embeddingsStatusDict);
+    const sourceCol = db._collection(embeddingsStatusDict["collection"]);
+    const dCol = db._collection(embeddingsStatusDict["destination_collection"]);
+    const embedding_field_name = embeddingsStatusDict["emb_field_name"];
+    query`
+        FOR doc in ${sourceCol}
+          FILTER doc.${sourceFieldName} != null
+          LET emb_docs = (
+            FOR emb_d in ${dCol}
+              FILTER emb_d.doc_key == doc._key
+              FILTER emb_d.${embedding_field_name} != null
+              LIMIT 1
+              RETURN 1
+          )
+          FILTER LENGTH(emb_docs) == 0
+          INSERT { _key: doc._key } INTO ${embeddingsRunCol}
+    `;
+    return embeddingsRunCol.name();
+}
+
+function createAndAddEmbeddingsRunCollection(embeddingsStatusDict, sourceFieldName) {
+    if (embeddingsStatusDict["destination_collection"] === embeddingsStatusDict["collection"]) {
+        return createAndAddEmbeddingsRunCollectionSameCollection(embeddingsStatusDict, sourceFieldName);
+    } else {
+        return createAndAddEmbeddingsRunCollectionSeparateCollection(embeddingsStatusDict, sourceFieldName);
+    }
+}
+
 exports.getDestinationCollectionName = getDestinationCollectionName;
 exports.getEmbeddingsFieldName = getEmbeddingsFieldName;
 exports.deleteEmbeddingsFieldEntries = deleteEmbeddingsFieldEntries;
 exports.getCountDocumentsWithoutEmbedding = getCountDocumentsWithoutEmbedding;
+exports.createAndAddEmbeddingsRunCollection = createAndAddEmbeddingsRunCollection;

--- a/services/emb_collections_service.js
+++ b/services/emb_collections_service.js
@@ -2,7 +2,7 @@
 
 const {query, db} = require("@arangodb");
 
-function nameForCollectionAndModel(collectionName, modelName) {
+function colNameForCollectionAndModel(collectionName, modelName) {
     return `emb_${collectionName}_${modelName}`;
 }
 
@@ -12,7 +12,7 @@ function getDestinationCollectionName(collectionName, separateCollection, modelM
         return collectionName;
     }
     // Otherwise create the separate collection name
-    const colName = nameForCollectionAndModel(collectionName, modelMetadata.name);
+    const colName = colNameForCollectionAndModel(collectionName, modelMetadata.name);
 
     // And create it if it doesn't already exist
     if (!db._collection(colName)) {

--- a/services/emb_generation_service.js
+++ b/services/emb_generation_service.js
@@ -7,16 +7,22 @@ const {query, db} = require("@arangodb");
 
 const embeddingQueueName = "embeddings_generation";
 
-function queueCollectionBatch(i, batchSize, colName, fieldName, modelMetadata, embeddingsQueue, destinationCollection, separateCollection, isLastBatch) {
+const scripts = {
+    NODE: "createNodeEmbeddings",
+    GRAPH: "createGraphEmbeddings"
+};
+
+function queueBatch(scriptName, i, batchSize, graphName, colName, fieldName, modelMetadata, embeddingsQueue, destinationCollection, separateCollection, isLastBatch) {
     embeddingsQueue.push(
         {
             mount: context.mount,
-            name: "createNodeEmbeddings"
+            name: scriptName
         },
         {
             collectionName: colName,
             batchIndex: i,
             modelMetadata,
+            graphName,
             fieldName,
             batchSize,
             destinationCollection,
@@ -26,59 +32,11 @@ function queueCollectionBatch(i, batchSize, colName, fieldName, modelMetadata, e
     );
 }
 
-function queueGraphBatch(i, batchSize, colName, graphName, fieldName, modelMetadata, embeddingsQueue, destinationCollection, separateCollection) {
-    embeddingsQueue.push(
-        {
-            mount: context.mount,
-            name: "createGraphEmbeddings"
-        },
-        {
-            collectionName: colName,
-            batchIndex: i,
-            graphName,
-            modelMetadata,
-            fieldName,
-            batchSize,
-            destinationCollection,
-            separateCollection
-        }
-    );
-}
-
 /**
- * Queue batch jobs to generate embeddings for a specified collection.
+ * Queue batch jobs to generate embeddings for a specified model/scriptType.
  * Returns true if batch jobs have been queued. This does NOT mean that they've succeeded yet.
  */
-function generateBatchesCollection(colName, fieldName, destinationCollection, separateCollection, modelMetadata) {
-    const myCol = db._collection(colName);
-    const numberOfDocuments = query`
-    RETURN COUNT(
-        FOR doc in ${myCol}
-        FILTER doc.${fieldName} != null
-        RETURN 1
-    )
-    `.toArray();
-
-    const batch_size = modelMetadata.metadata.inference_batch_size;
-    const numBatches = Math.ceil(numberOfDocuments / batch_size);
-
-    const embQ = queues.create(embeddingQueueName);
-
-    Array(numBatches)
-        .fill()
-        .map((_, i) => i)
-        .forEach(i => queueCollectionBatch(
-            i, batch_size, colName, fieldName, modelMetadata, embQ, destinationCollection, separateCollection, i == (numBatches - 1)
-        ));
-
-    return true;
-}
-
-/**
- * Queue batch jobs to generate embeddings for a specified graph.
- * Returns true if batch jobs have been queued. This does NOT mean that they've succeeded yet.
- */
-function generateBatchesGraph(graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata) {
+function generateBatches(scriptType, graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata) {
     const myCol = db._collection(collectionName);
     const numberOfDocuments = query`
     RETURN COUNT(
@@ -96,35 +54,38 @@ function generateBatchesGraph(graphName, collectionName, fieldName, destinationC
     Array(numBatches)
         .fill()
         .map((_, i) => i)
-        .forEach(i => queueGraphBatch(
-            i, batch_size, collectionName, graphName, fieldName, modelMetadata, embQ, destinationCollection, separateCollection
+        .forEach(i => queueBatch(
+            scriptType,
+            i,
+            batch_size,
+            collectionName,
+            graphName,
+            fieldName,
+            modelMetadata,
+            embQ,
+            destinationCollection,
+            separateCollection,
+            i === (numBatches - 1)
         ));
-
-    return true;
 }
 
 function generateBatchesForModel(graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata) {
     switch (modelMetadata.model_type) {
         case modelTypes.WORD_EMBEDDING: {
-            const isQueued = generateBatchesCollection(collectionName, fieldName, destinationCollection, separateCollection, modelMetadata);
-            if (isQueued) {
-                return `Queued generation of embeddings for collection ${collectionName} using ${modelMetadata.name} on the ${fieldName} field`;
-            }
-            break;
+            generateBatches(scripts.NODE, graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata);
+            return true;
         }
         case modelTypes.GRAPH_MODEL: {
             if (!graphName) {
                 throw new Error("Requested to generate graph embeddings but no graph is provided");
             }
-            const isQueued = generateBatchesGraph(graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata);
-            if (isQueued) {
-                return `Queued generation of embeddings for collection ${collectionName} traversing ${graphName} using ${modelMetadata.name} on the ${fieldName} field`;
-            }
-            break;
+            generateBatches(scripts.GRAPH, graphName, collectionName, fieldName, destinationCollection, separateCollection, modelMetadata);
+            return true;
         }
         default:
             throw new Error(`Error: unrecognized model type: ${modelMetadata.model_type}`);
     }
+    throw new Error("Unable to queue batches.");
 }
 
 exports.generateBatchesForModel = generateBatchesForModel;

--- a/services/emb_generation_service.js
+++ b/services/emb_generation_service.js
@@ -52,7 +52,7 @@ function generateBatches(scriptType, graphName, embeddingsStatusDict, fieldName,
     // Create the embeddings run collection
     const embeddingsRunColName = createAndAddEmbeddingsRunCollection(embeddingsStatusDict, fieldName);
 
-    const batch_size = modelMetadata.metadata.inference_batch_size;
+    const batch_size = 1000;
     const numBatches = Math.ceil(numberOfDocuments / batch_size);
 
     const embQ = queues.create(embeddingQueueName);

--- a/services/emb_generation_service.js
+++ b/services/emb_generation_service.js
@@ -21,13 +21,13 @@ function queueBatch(scriptName, i, batchSize, graphName, colName, fieldName, mod
         {
             collectionName: colName,
             batchIndex: i,
-            modelMetadata,
-            graphName,
-            fieldName,
-            batchSize,
-            destinationCollection,
-            separateCollection,
-            isLastBatch
+            modelMetadata: modelMetadata,
+            graphName: graphName,
+            fieldName: fieldName,
+            batchSize: batchSize,
+            destinationCollection: destinationCollection,
+            separateCollection: separateCollection,
+            isLastBatch: isLastBatch
         }
     );
 }
@@ -58,8 +58,8 @@ function generateBatches(scriptType, graphName, collectionName, fieldName, desti
             scriptType,
             i,
             batch_size,
-            collectionName,
             graphName,
+            collectionName,
             fieldName,
             modelMetadata,
             embQ,
@@ -85,7 +85,6 @@ function generateBatchesForModel(graphName, collectionName, fieldName, destinati
         default:
             throw new Error(`Error: unrecognized model type: ${modelMetadata.model_type}`);
     }
-    throw new Error("Unable to queue batches.");
 }
 
 exports.generateBatchesForModel = generateBatchesForModel;

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -2,9 +2,8 @@
 const {updateStatusByCollectionDestinationAndEmbName} = require("../db/embeddings_status");
 const {createStatus} = require("../db/embeddings_status");
 const {getStatusesByCollectionDestinationAndEmbName} = require("../db/embeddings_status");
-const {query, db} = require("@arangodb");
 const {getEmbeddingsFieldName} = require("./emb_collections_service");
-const {embeddingsStatusCollectionName, embeddingsStatus} = require("../model/embeddings_status");
+const {embeddingsStatus} = require("../model/embeddings_status");
 
 /**
  * Get the status of how the embeddings generation is going.

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -42,7 +42,7 @@ function getEmbeddingsStatusDict(collectionName, destinationCollectionName, fiel
  * Create a new status of how the embeddings generation is going.
  */
 function createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata) {
-    createStatus(
+    return createStatus(
         collectionName,
         destinationCollectionName,
         getEmbeddingsFieldName(fieldName, modelMetadata),

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -10,7 +10,7 @@ const {embeddingsStatus} = require("../model/embeddings_status");
  */
 function getEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata) {
     const res = getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, getEmbeddingsFieldName(fieldName, modelMetadata))
-    if (res.length == 0) {
+    if (res.length === 0) {
         return embeddingsStatus.DOES_NOT_EXIST;
     }
     return res[0]["status"];
@@ -21,7 +21,7 @@ function getEmbeddingsStatus(collectionName, destinationCollectionName, fieldNam
  */
 function getEmbeddingsStatusDocId(collectionName, destinationCollectionName, fieldName, modelMetadata) {
     const res = getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, getEmbeddingsFieldName(fieldName, modelMetadata))
-    if (res.length == 0) {
+    if (res.length === 0) {
         return null;
     }
     return res[0]["_key"];

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -22,6 +22,23 @@ function getEmbeddingsStatus(collectionName, destinationCollectionName, fieldNam
 }
 
 /**
+ * Get the document ID of an embedding status. Returns `null` if not found.
+ */
+function getEmbeddingsStatusDocId(collectionName, destinationCollectionName, fieldName, modelMetadata) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    const res = query`
+    FOR d in ${col}
+        FILTER d.collection == ${collectionName}
+        AND d.destination_collection == ${destinationCollectionName}
+        AND d.emb_field_name == ${getEmbeddingsFieldName(fieldName, modelMetadata)}
+        RETURN d
+    `.toArray();
+    if (res.length == 0) {
+        return null;
+    }
+    return res[0]["_key"];
+}
+/**
  * Create a new status of how the embeddings generation is going.
  */
 function createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata) {
@@ -50,5 +67,6 @@ function updateEmbeddingsStatus(newStatus, collectionName, destinationCollection
     `;
 }
 exports.getEmbeddingsStatus = getEmbeddingsStatus;
+exports.getEmbeddingsStatusDocId = getEmbeddingsStatusDocId;
 exports.createEmbeddingsStatus = createEmbeddingsStatus;
 exports.updateEmbeddingsStatus = updateEmbeddingsStatus;

--- a/utils/db.js
+++ b/utils/db.js
@@ -1,0 +1,17 @@
+/**
+ * This module contains database interaction utilities
+ */
+"use strict";
+const {db} = require("@arangodb");
+const graph_module = require("@arangodb/general-graph");
+
+function checkGraphIsPresent(graphName) {
+    return graph_module._list().some(g => g === graphName)
+}
+
+function checkCollectionIsPresent(collectionName) {
+    return db._collections().map(c => c.name()).some(n => n === collectionName)
+}
+
+exports.checkGraphIsPresent = checkGraphIsPresent;
+exports.checkCollectionIsPresent = checkCollectionIsPresent;

--- a/utils/profiling.js
+++ b/utils/profiling.js
@@ -1,0 +1,21 @@
+"use strict";
+// TODO: Check if this module can be supported, as new Date() can be pretty unreliable...
+// const performance = {
+//     now: function(start) {
+//         if ( !start ) return process.hrtime();
+//         var end = process.hrtime(start);
+//         return Math.round((end[0]*1000) + (end[1]/1000000));
+//     }
+// }
+
+function profileCall(fn) {
+    return function() {
+        const start = new Date();
+        const result = fn.apply(this, arguments);
+        const end = new Date();
+        console.log(`Call to ${fn.name} took ${end - start} ms.`);
+        return result;
+    };
+}
+
+exports.profileCall = profileCall;


### PR DESCRIPTION
This PR:
- Adds Update/Resume functionality
- Adds an index to `doc_key` if using a separate collection
- Creates temporary collection to speed up document retrieval during embeddings generation
- Add Profiling Logs for calls and compute node calls
- Separate foxx queue job batch size from model batch size. Currently set foxx job batch size to 1000.
- Foxx queue jobs now spawn next jobs, instead of all being put on queue at once.