### PR TITLE
Background Embeddings Management + Refactor

### DIFF
--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -1,15 +1,13 @@
 "use strict";
 
-const {getCountDocumentsWithoutEmbedding, pruneEmbeddings} = require("../services/emb_collections_service");
-const {getOrCreateEmbeddingsStatusDict, updateEmbeddingsStatusDict} = require("../services/emb_status_service");
+const {getOrCreateEmbeddingsStatusDict} = require("../services/emb_status_service");
 const {checkCollectionIsPresent, checkGraphIsPresent} = require("../utils/db");
 const {modelTypes} = require("../model/model_metadata");
-const {embeddingsStatus} = require("../model/embeddings_status");
 const {sendInvalidInputMessage} = require("../utils/invalid_input");
 const {retrieveModel} = require("../services/model_metadata_service");
-const {generateBatchesForModel} = require("../services/emb_generation_service");
 const {getDestinationCollectionName} = require("../services/emb_collections_service");
 const {profileCall} = require("../utils/profiling");
+const {manageEmbeddingsForDocFieldAndModel} = require("../services/emb_management_service");
 
 function initialValidationGenerateEmbParams(req, res) {
     // check if model type is valid
@@ -28,84 +26,6 @@ function initialValidationGenerateEmbParams(req, res) {
         sendInvalidInputMessage(res,
             "Please supply a fieldName to use for embeddings generation");
     }
-}
-
-function pruneEmbeddingsIfNeeded(embeddingsStatusDict, overwriteExisting) {
-    if (!overwriteExisting) {
-        switch (embeddingsStatusDict["status"]) {
-            case embeddingsStatus.DOES_NOT_EXIST:
-            case embeddingsStatus.RUNNING:
-            case embeddingsStatus.RUNNING_FAILED:
-                // Don't need to prune in these cases
-                return;
-            default:
-                // NOP
-        }
-    }
-    pruneEmbeddings(embeddingsStatusDict);
-}
-
-function determineGenerationNeededForStatus(embeddingsStatusDict, overwriteExisting) {
-    const start_msg = "Queued generation of embeddings!";
-    let message = "";
-    let shouldEmbed = true;
-
-    switch (embeddingsStatusDict["status"]) {
-        case embeddingsStatus.DOES_NOT_EXIST:
-        case embeddingsStatus.FAILED:
-            message = start_msg;
-            break;
-        case embeddingsStatus.RUNNING:
-        case embeddingsStatus.RUNNING_FAILED:
-            if (overwriteExisting) {
-                message = "Overwriting old embeddings. " + start_msg;
-            } else {
-                shouldEmbed = false;
-                message = "Generation of embeddings is already running!";
-            }
-            break;
-        case embeddingsStatus.COMPLETED:
-            // first check if we have any documents that don't already have an embedding
-            if (!overwriteExisting) {
-                if (getCountDocumentsWithoutEmbedding(embeddingsStatusDict, embeddingsStatusDict["field_name"]) !== 0) {
-                    message = "Adding new embeddings. " + start_msg;
-                } else {
-                    shouldEmbed = false;
-                    message = "These embeddings have already been generated!";
-                }
-            } else {
-                message = "Overwriting old embeddings. " + start_msg;
-            }
-            break;
-    }
-
-    return {
-        shouldGenerate: shouldEmbed,
-        message: message
-    };
-}
-
-
-function handleGenerationForModel(embStatusDict, graphName, sourceCollectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata, overwriteExisting) {
-    let response_dict = {};
-
-    pruneEmbeddingsIfNeeded(embStatusDict, overwriteExisting);
-
-    const {shouldGenerate, message} = determineGenerationNeededForStatus(embStatusDict, overwriteExisting);
-    response_dict["message"] = message;
-
-    if (shouldGenerate) {
-        updateEmbeddingsStatusDict(embStatusDict, embeddingsStatus.RUNNING);
-        if (generateBatchesForModel(graphName, embStatusDict, fieldName, separateCollection, modelMetadata, overwriteExisting)) {
-            // NOP
-        } else {
-            updateEmbeddingsStatusDict(embStatusDict, embeddingsStatus.COMPLETED);
-            response_dict["message"] = "Nothing to embed.";
-        }
-    }
-
-    response_dict["embeddings_status_id"] = embStatusDict["_key"];
-    return response_dict;
 }
 
 function generateEmbeddings(req, res) {
@@ -134,7 +54,7 @@ function generateEmbeddings(req, res) {
 
     const destinationCollectionName = profileCall(getDestinationCollectionName)(collectionName, separateCollection, modelMetadata);
     const embStatusDict = profileCall(getOrCreateEmbeddingsStatusDict)(collectionName, destinationCollectionName, fieldName, modelMetadata);
-    const response_dict = profileCall(handleGenerationForModel)(embStatusDict, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata, overwriteExisting);
+    const response_dict = profileCall(manageEmbeddingsForDocFieldAndModel)(embStatusDict, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata, overwriteExisting);
     res.json(response_dict);
 }
 

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -53,7 +53,7 @@ function generateEmbeddings(req, res) {
     }
 
     const destinationCollectionName = profileCall(getDestinationCollectionName)(collectionName, separateCollection, modelMetadata);
-    const embStatusDict = profileCall(getOrCreateEmbeddingsStatusDict)(collectionName, destinationCollectionName, fieldName, modelMetadata);
+    const embStatusDict = profileCall(getOrCreateEmbeddingsStatusDict)(graphName, collectionName, destinationCollectionName, fieldName, modelMetadata);
     const response_dict = profileCall(manageEmbeddingsForDocFieldAndModel)(embStatusDict, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata, overwriteExisting);
     res.json(response_dict);
 }

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -54,7 +54,7 @@ function generateEmbeddings(req, res) {
 
     const destinationCollectionName = profileCall(getDestinationCollectionName)(collectionName, separateCollection, modelMetadata);
     const embStatusDict = profileCall(getOrCreateEmbeddingsStatusDict)(graphName, collectionName, destinationCollectionName, fieldName, modelMetadata);
-    const response_dict = profileCall(manageEmbeddingsForDocFieldAndModel)(embStatusDict, graphName, collectionName, fieldName, destinationCollectionName, separateCollection, modelMetadata, overwriteExisting);
+    const response_dict = profileCall(manageEmbeddingsForDocFieldAndModel)(embStatusDict, graphName, modelMetadata, overwriteExisting);
     res.json(response_dict);
 }
 

--- a/controllers/generate_embeddings.js
+++ b/controllers/generate_embeddings.js
@@ -54,7 +54,7 @@ function generateEmbeddings(req, res) {
 
     const destinationCollectionName = profileCall(getDestinationCollectionName)(collectionName, separateCollection, modelMetadata);
     const embStatusDict = profileCall(getOrCreateEmbeddingsStatusDict)(graphName, collectionName, destinationCollectionName, fieldName, modelMetadata);
-    const response_dict = profileCall(manageEmbeddingsForDocFieldAndModel)(embStatusDict, graphName, modelMetadata, overwriteExisting);
+    const response_dict = profileCall(manageEmbeddingsForDocFieldAndModel)(embStatusDict, modelMetadata, overwriteExisting);
     res.json(response_dict);
 }
 

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -67,8 +67,21 @@ function updateStatusByCollectionDestinationAndEmbName(collectionName, destinati
     `;
 }
 
+function updateEmbeddingsStatusByKey(embeddingsStatusKey, newStatus, timestamp) {
+    const col = db._collection(embeddingsStatusCollectionName);
+    return query`
+    FOR d in ${col}
+        FILTER d._key == ${embeddingsStatusKey}
+        UPDATE d._key WITH {
+            status: ${newStatus},
+            last_run_timestamp: ${timestamp} 
+        } IN ${col} RETURN NEW
+    `.toArray()[0];
+}
+
 exports.getStatusByKey = getStatusByKey;
 exports.getStatusesByCollectionAndEmbName = getStatusesByCollectionAndEmbName;
 exports.getStatusesByCollectionDestinationAndEmbName = getStatusesByCollectionDestinationAndEmbName;
 exports.createStatus = createStatus;
 exports.updateStatusByCollectionDestinationAndEmbName = updateStatusByCollectionDestinationAndEmbName;
+exports.updateEmbeddingsStatusByKey = updateEmbeddingsStatusByKey;

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -41,19 +41,34 @@ function getStatusesByCollectionDestinationAndEmbName(collectionName, destinatio
 
 function createStatus(graphName, collectionName, destinationCollectionName, embeddingsFieldName, fieldName, modelMetadata, status, timestamp) {
     const col = db._collection(embeddingsStatusCollectionName);
-    return query`
-    INSERT {
-        graph_name: ${graphName},
-        model_key: ${modelMetadata._key},
-        model_type: ${modelMetadata.model_type},
-        collection: ${collectionName},
-        destination_collection: ${destinationCollectionName},
-        emb_field_name: ${embeddingsFieldName},
-        field_name: ${fieldName},
-        status: ${status},
-        last_run_timestamp: ${timestamp}
-    } INTO ${col} RETURN NEW
-    `.toArray()[0];
+    if (graphName !== undefined && graphName.length > 0) {
+        return query`
+        INSERT {
+            graph_name: ${graphName},
+            model_key: ${modelMetadata["_key"]},
+            model_type: ${modelMetadata["model_type"]},
+            collection: ${collectionName},
+            destination_collection: ${destinationCollectionName},
+            emb_field_name: ${embeddingsFieldName},
+            field_name: ${fieldName},
+            status: ${status},
+            last_run_timestamp: ${timestamp}
+        } INTO ${col} RETURN NEW
+        `.toArray()[0];
+    } else {
+        return query`
+        INSERT {
+            model_key: ${modelMetadata["_key"]},
+            model_type: ${modelMetadata["model_type"]},
+            collection: ${collectionName},
+            destination_collection: ${destinationCollectionName},
+            emb_field_name: ${embeddingsFieldName},
+            field_name: ${fieldName},
+            status: ${status},
+            last_run_timestamp: ${timestamp}
+        } INTO ${col} RETURN NEW
+        `.toArray()[0];
+    }
 }
 
 function updateStatusByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, embeddingsFieldName, newStatus, timestamp) {

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -39,10 +39,13 @@ function getStatusesByCollectionDestinationAndEmbName(collectionName, destinatio
     `.toArray();
 }
 
-function createStatus(collectionName, destinationCollectionName, embeddingsFieldName, fieldName, status, timestamp) {
+function createStatus(graphName, collectionName, destinationCollectionName, embeddingsFieldName, fieldName, modelMetadata, status, timestamp) {
     const col = db._collection(embeddingsStatusCollectionName);
     return query`
     INSERT {
+        graph_name: ${graphName},
+        model_key: ${modelMetadata._key},
+        model_type: ${modelMetadata.model_type},
         collection: ${collectionName},
         destination_collection: ${destinationCollectionName},
         emb_field_name: ${embeddingsFieldName},

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -39,13 +39,14 @@ function getStatusesByCollectionDestinationAndEmbName(collectionName, destinatio
     `.toArray();
 }
 
-function createStatus(collectionName, destinationCollectionName, embeddingsFieldName, status, timestamp) {
+function createStatus(collectionName, destinationCollectionName, embeddingsFieldName, fieldName, status, timestamp) {
     const col = db._collection(embeddingsStatusCollectionName);
     return query`
     INSERT {
         collection: ${collectionName},
         destination_collection: ${destinationCollectionName},
         emb_field_name: ${embeddingsFieldName},
+        field_name: ${fieldName},
         status: ${status},
         last_run_timestamp: ${timestamp}
     } INTO ${col} RETURN NEW

--- a/db/embeddings_status.js
+++ b/db/embeddings_status.js
@@ -97,9 +97,18 @@ function updateEmbeddingsStatusByKey(embeddingsStatusKey, newStatus, timestamp) 
     `.toArray()[0];
 }
 
+function listEmbeddingsStatuses() {
+    const col = db._collection(embeddingsStatusCollectionName);
+    return query`
+    FOR d in ${col}
+        RETURN d
+    `.toArray();
+}
+
 exports.getStatusByKey = getStatusByKey;
 exports.getStatusesByCollectionAndEmbName = getStatusesByCollectionAndEmbName;
 exports.getStatusesByCollectionDestinationAndEmbName = getStatusesByCollectionDestinationAndEmbName;
 exports.createStatus = createStatus;
 exports.updateStatusByCollectionDestinationAndEmbName = updateStatusByCollectionDestinationAndEmbName;
 exports.updateEmbeddingsStatusByKey = updateEmbeddingsStatusByKey;
+exports.listEmbeddingsStatuses = listEmbeddingsStatuses;

--- a/manifest.json
+++ b/manifest.json
@@ -19,11 +19,27 @@
       "type": "boolean",
       "default": false,
       "description": "Enable log messages"
+    },
+    "enableBackgroundManagement": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable background management of embeddings (to respond to document changes etc.)"
+    },
+    "enableQueues": {
+      "type": "boolean",
+      "default": true,
+      "description": "If disabled, all background jobs, including generation of embeddings, will be cancelled."
+    },
+    "backgroundManagementInterval": {
+      "type": "number",
+      "default": 7.2e6,
+      "description": "Time (in milliseconds), between background management checks."
     }
   },
   "scripts": {
     "setup": "scripts/setup.js",
     "createNodeEmbeddings": "scripts/create_node_embeddings.js",
-    "createGraphEmbeddings": "scripts/create_graph_embeddings.js"
+    "createGraphEmbeddings": "scripts/create_graph_embeddings.js",
+    "backgroundEmbeddingsManagement": "scripts/manage_embedding_collections.js"
   }
 }

--- a/model/embeddings_status.js
+++ b/model/embeddings_status.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const {context} = require("@arangodb/locals");
+const {modelTypes} = require("./model_metadata");
 
 const embeddingsStatus = {
     RUNNING: "running",
@@ -15,6 +16,12 @@ const embeddingsStatusSchema = {
     rule: {
         "type": "object",
         "properties": {
+           // TODO: FIX THIS AND ADD IT TO THE METHODS
+            "graph_name": { "type": "string" },
+            "model_key": { "type": "string" },
+            "model_type": {
+                "enum": Object.values(modelTypes)
+            },
             "emb_field_name": { "type": "string" },
             "field_name": { "type": "string" },
             "collection": { "type": "string" },
@@ -30,7 +37,15 @@ const embeddingsStatusSchema = {
             },
             "last_run_timestamp": { "type": "string" }
         },
-        "required": ["emb_field_name", "collection", "destination_collection", "status", "last_run_timestamp"]
+        "required": [
+            "model_key",
+            "model_type",
+            "emb_field_name",
+            "collection",
+            "destination_collection",
+            "status",
+            "last_run_timestamp"
+        ]
     },
     level: "moderate",
     message: "The embeddings status is invalid"

--- a/model/embeddings_status.js
+++ b/model/embeddings_status.js
@@ -16,6 +16,7 @@ const embeddingsStatusSchema = {
         "type": "object",
         "properties": {
             "emb_field_name": { "type": "string" },
+            "field_name": { "type": "string" },
             "collection": { "type": "string" },
             "destination_collection": { "type": "string" },
             "status": {
@@ -24,6 +25,7 @@ const embeddingsStatusSchema = {
                     embeddingsStatus.RUNNING_FAILED,
                     embeddingsStatus.FAILED,
                     embeddingsStatus.COMPLETED,
+                    embeddingsStatus.DOES_NOT_EXIST,
                 ]
             },
             "last_run_timestamp": { "type": "string" }

--- a/model/embeddings_status.js
+++ b/model/embeddings_status.js
@@ -16,7 +16,6 @@ const embeddingsStatusSchema = {
     rule: {
         "type": "object",
         "properties": {
-           // TODO: FIX THIS AND ADD IT TO THE METHODS
             "graph_name": { "type": "string" },
             "model_key": { "type": "string" },
             "model_type": {

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -11,6 +11,7 @@ const {getEmbeddingsStatus, updateEmbeddingsStatus} = require("../services/emb_s
 const {queueBatch, scripts} = require("../services/emb_generation_service");
 const {embeddingsStatus} = require("../model/embeddings_status");
 const {EMB_QUEUE_NAME} = require("../utils/embeddings_queue");
+const {embeddingsTargetsAreValid} = require("../utils/embeddings_target");
 
 const {argv} = module.context;
 
@@ -239,4 +240,8 @@ function createNodeEmbeddings() {
     }
 }
 
-profileCall(createNodeEmbeddings)();
+if (!embeddingsTargetsAreValid(null, collectionName)) {
+    logMsg(`Embeddings target collection ${collectionName} is no longer valid. Aborting generation...`);
+} else {
+    profileCall(createNodeEmbeddings)();
+}

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -168,7 +168,7 @@ function getAndSaveNodeEmbeddingsForMiniBatch(collection, dCollection) {
         const requestData = miniBatch.map(x => x["field"]);
         const res = profileCall(invokeEmbeddingModel)(requestData);
 
-        if (res.status == 200) {
+        if (res.status === 200) {
             logTimeElapsed(res.body);
             const embeddings = profileCall(extractEmbeddingsFromResponse)(res.body, modelMetadata.metadata.emb_dim);
             if (separateCollection) {

--- a/scripts/create_node_embeddings.js
+++ b/scripts/create_node_embeddings.js
@@ -26,6 +26,7 @@ function getDocumentsToEmbed(nDocs, startInd, docCollection, embeddingsRunCol, f
             LIMIT ${startInd}, ${nDocs}
             FOR doc in ${docCollection}
                 FILTER embRunDoc._key == doc._key
+                FILTER doc.${fieldToEmbed} != null
                 RETURN {
                   "_key": doc._key,
                   "field": doc.${fieldToEmbed}

--- a/scripts/manage_embedding_collections.js
+++ b/scripts/manage_embedding_collections.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const {logMsg, logErr} = require("../utils/logging");
+const {rescheduleManagementQueueJob, cancelBackgroundManagementJobs, manageEmbeddingCollections, canManageEmbeddings} = require("../services/collections_management_service");
+
+
+if (canManageEmbeddings()) {
+    try {
+        manageEmbeddingCollections();
+    } catch (e) {
+        logErr("Error occured during embeddings management!");
+        logErr(e, e.stack);
+    } finally {
+        rescheduleManagementQueueJob();
+    }
+} else {
+    cancelBackgroundManagementJobs();
+    logMsg("Background management queue disabled. If you would like to re-enable it - this script will need to be manually triggered");
+}

--- a/scripts/manage_embedding_collections.js
+++ b/scripts/manage_embedding_collections.js
@@ -1,8 +1,11 @@
 "use strict";
 
 const {logMsg, logErr} = require("../utils/logging");
-const {rescheduleManagementQueueJob, cancelBackgroundManagementJobs, manageEmbeddingCollections, canManageEmbeddings} = require("../services/collections_management_service");
+const {rescheduleManagementQueueJobIfNeeded, cancelBackgroundManagementJobs, manageEmbeddingCollections, canManageEmbeddings} = require("../services/collections_management_service");
 
+const {argv} = module.context;
+
+const {currentInterval} = argv[0];
 
 if (canManageEmbeddings()) {
     try {
@@ -11,7 +14,7 @@ if (canManageEmbeddings()) {
         logErr("Error occured during embeddings management!");
         logErr(e, e.stack);
     } finally {
-        rescheduleManagementQueueJob();
+        rescheduleManagementQueueJobIfNeeded(currentInterval);
     }
 } else {
     cancelBackgroundManagementJobs();

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -3,6 +3,7 @@
 const db = require("@arangodb").db;
 const {modelTypes, metadataCollectionName, modelMetadataSchema} = require("../model/model_metadata");
 const {embeddingsStatusCollectionName, embeddingsStatusSchema}  = require("../model/embeddings_status");
+const {pushManagementQueueJob, getBackgroundManagementQueue} = require("./manage_embedding_collections");
 
 
 function createModelMetadataCollection() {
@@ -103,3 +104,4 @@ function seedMetadataCol(collection) {
 const modelMetadataCol = createModelMetadataCollection();
 seedMetadataCol(modelMetadataCol);
 createEmbeddingsStatusCollection();
+pushManagementQueueJob(getBackgroundManagementQueue());

--- a/services/collections_management_service.js
+++ b/services/collections_management_service.js
@@ -21,7 +21,7 @@ function manageEmbeddingsForStatusDict(embeddingsStatusDict) {
         logMsg(`Unable to find model ${embeddingsStatusDict["model_key"]}, skipping embeddings for ${embeddingsStatusDict["field_name"]} on ${embeddingsStatusDict["collection"]}`)
     }
 
-    manageEmbeddingsForDocFieldAndModel(embeddingsStatusDict, embeddingsStatusDict["graph_name"], modelMetadata, false);
+    manageEmbeddingsForDocFieldAndModel(embeddingsStatusDict, modelMetadata, false);
 }
 
 function shouldManageEmbeddingsStatus(embeddingsStatusDict) {

--- a/services/collections_management_service.js
+++ b/services/collections_management_service.js
@@ -1,0 +1,93 @@
+"use strict";
+
+const queues = require("@arangodb/foxx/queues");
+const {context} = require("@arangodb/locals");
+const {getModelByKey} = require("../services/model_metadata_service");
+const {logMsg} = require("../utils/logging");
+const {manageEmbeddingsForDocFieldAndModel} = require("../services/emb_management_service");
+const {embeddingsStatus} = require("../model/embeddings_status");
+const {listEmbeddingsStatuses} = require("../db/embeddings_status");
+
+const BACKGROUND_MANAGEMENT_QUEUE_NAME = "background_management_queue";
+const BACKGROUND_MANAGEMENT_SCRIPT_NAME = "backgroundEmbeddingsManagement";
+
+function getModelMetadataForEmbeddingsStatus(embeddingsStatusDict) {
+    return getModelByKey(embeddingsStatusDict["model_key"]);
+}
+
+function manageEmbeddingsForStatusDict(embeddingsStatusDict) {
+    const modelMetadata = getModelMetadataForEmbeddingsStatus(embeddingsStatusDict);
+    if (modelMetadata === null) {
+        logMsg(`Unable to find model ${embeddingsStatusDict["model_key"]}, skipping embeddings for ${embeddingsStatusDict["field_name"]} on ${embeddingsStatusDict["collection"]}`)
+    }
+
+    manageEmbeddingsForDocFieldAndModel(embeddingsStatusDict, embeddingsStatusDict["graph_name"], modelMetadata, false);
+}
+
+function shouldManageEmbeddingsStatus(embeddingsStatusDict) {
+    switch (embeddingsStatusDict["status"]) {
+        // Only update embeddings that are completed
+        case embeddingsStatus.COMPLETED:
+        case embeddingsStatus.FAILED:
+            return true;
+        default:
+            return false;
+    }
+}
+
+function manageEmbeddingCollections() {
+    listEmbeddingsStatuses()
+        .filter(shouldManageEmbeddingsStatus)
+        .forEach(manageEmbeddingsForStatusDict);
+}
+function getBackgroundManagementQueue() {
+    return queues.create(BACKGROUND_MANAGEMENT_QUEUE_NAME);
+}
+
+function cancelPendingQueueJobs(backQueue) {
+    backQueue.progress().forEach((jobId) => {
+        backQueue.delete(jobId);
+    })
+    backQueue.pending().forEach((jobId) => {
+        backQueue.delete(jobId);
+    });
+}
+
+function cancelBackgroundManagementJobs() {
+    const backQueue = getBackgroundManagementQueue();
+    cancelPendingQueueJobs(backQueue);
+}
+
+function pushManagementQueueJob(backQueue) {
+    const intervalInMS = context.configuration.backgroundManagementInterval;
+    backQueue.push(
+        {
+            mount: context.mount,
+            name: BACKGROUND_MANAGEMENT_SCRIPT_NAME
+        },
+        {},
+        {
+            delayUntil: Date.now() + intervalInMS,
+            repeatTimes: -1,
+            repeatDelay: intervalInMS,
+        }
+    );
+}
+
+function rescheduleManagementQueueJob() {
+    const backQueue = getBackgroundManagementQueue();
+    // No way to cache previous management interval to compare, so must cancel if successful
+    cancelPendingQueueJobs(backQueue);
+    pushManagementQueueJob(backQueue);
+}
+
+function canManageEmbeddings() {
+    return context.configuration.enableQueues && context.configuration.enableBackgroundManagement;
+}
+
+exports.pushManagementQueueJob = pushManagementQueueJob;
+exports.getBackgroundManagementQueue = getBackgroundManagementQueue;
+exports.canManageEmbeddings = canManageEmbeddings;
+exports.manageEmbeddingCollections = manageEmbeddingCollections;
+exports.rescheduleManagementQueueJob = rescheduleManagementQueueJob;
+exports.cancelBackgroundManagementJobs = cancelBackgroundManagementJobs;

--- a/services/collections_management_service.js
+++ b/services/collections_management_service.js
@@ -65,7 +65,9 @@ function pushManagementQueueJob(backQueue) {
             mount: context.mount,
             name: BACKGROUND_MANAGEMENT_SCRIPT_NAME
         },
-        {},
+        {
+            currentInterval: intervalInMS
+        },
         {
             delayUntil: Date.now() + intervalInMS,
             repeatTimes: -1,
@@ -74,11 +76,13 @@ function pushManagementQueueJob(backQueue) {
     );
 }
 
-function rescheduleManagementQueueJob() {
-    const backQueue = getBackgroundManagementQueue();
-    // No way to cache previous management interval to compare, so must cancel if successful
-    cancelPendingQueueJobs(backQueue);
-    pushManagementQueueJob(backQueue);
+function rescheduleManagementQueueJobIfNeeded(currentInterval) {
+    if (currentInterval !== context.configuration.backgroundManagementInterval) {
+        console.log("Rescheduling management job")
+        const backQueue = getBackgroundManagementQueue();
+        cancelPendingQueueJobs(backQueue);
+        pushManagementQueueJob(backQueue);
+    }
 }
 
 function canManageEmbeddings() {
@@ -89,5 +93,5 @@ exports.pushManagementQueueJob = pushManagementQueueJob;
 exports.getBackgroundManagementQueue = getBackgroundManagementQueue;
 exports.canManageEmbeddings = canManageEmbeddings;
 exports.manageEmbeddingCollections = manageEmbeddingCollections;
-exports.rescheduleManagementQueueJob = rescheduleManagementQueueJob;
+exports.rescheduleManagementQueueJobIfNeeded = rescheduleManagementQueueJobIfNeeded;
 exports.cancelBackgroundManagementJobs = cancelBackgroundManagementJobs;

--- a/services/emb_collections_service.js
+++ b/services/emb_collections_service.js
@@ -94,12 +94,13 @@ function pruneDocsWithChangedFieldsSameCollection(embeddingsStatusDict, fieldNam
     `;
 }
 
-function pruneDocsWithChangedFieldsSeparateCollection(embeddingsStatusDict, fieldName) {
+function pruneDocsWithChangedFieldsSeparateCollection(embeddingsStatusDict) {
     const dCol = db._collection(embeddingsStatusDict["destination_collection"]);
     const sCol = db._collection(embeddingsStatusDict["collection"]);
 
     const emb_field_name = embeddingsStatusDict["emb_field_name"];
     const emb_field_name_hash = `${emb_field_name}_hash`;
+    const field_name = embeddingsStatusDict["field_name"];
 
     query`
         FOR emb_doc in ${dCol}
@@ -109,7 +110,7 @@ function pruneDocsWithChangedFieldsSeparateCollection(embeddingsStatusDict, fiel
                     LIMIT 1
                     RETURN doc
             )
-            FILTER emb_doc.${emb_field_name_hash} != SHA1(corresponding.${fieldName})
+            FILTER emb_doc.${emb_field_name_hash} != SHA1(corresponding.${field_name})
             UPDATE emb_doc WITH {
                 ${emb_field_name}: null,
                 ${emb_field_name_hash}: null
@@ -117,11 +118,11 @@ function pruneDocsWithChangedFieldsSeparateCollection(embeddingsStatusDict, fiel
     `;
 }
 
-function pruneDocsWithChangedFields(embeddingsStatusDict, fieldName) {
+function pruneDocsWithChangedFields(embeddingsStatusDict) {
     if (embeddingsStatusDict["destination_collection"] === embeddingsStatusDict["collection"]) {
-        pruneDocsWithChangedFieldsSameCollection(embeddingsStatusDict, fieldName);
+        pruneDocsWithChangedFieldsSameCollection(embeddingsStatusDict);
     } else {
-        pruneDocsWithChangedFieldsSeparateCollection(embeddingsStatusDict, fieldName);
+        pruneDocsWithChangedFieldsSeparateCollection(embeddingsStatusDict);
     }
 }
 
@@ -144,9 +145,9 @@ function pruneDeletedDocs(embeddingsStatusDict) {
     }
 }
 
-function pruneEmbeddings(embeddingsStatusDict, fieldName) {
+function pruneEmbeddings(embeddingsStatusDict) {
     pruneDeletedDocs(embeddingsStatusDict);
-    pruneDocsWithChangedFields(embeddingsStatusDict, fieldName);
+    pruneDocsWithChangedFields(embeddingsStatusDict);
 }
 
 

--- a/services/emb_generation_service.js
+++ b/services/emb_generation_service.js
@@ -39,9 +39,9 @@ function queueBatch(scriptName, i, batchSize, numBatches, batchOffset, graphName
  * Queue batch jobs to generate embeddings for a specified model/scriptType.
  * Returns true if batch jobs have been queued. This does NOT mean that they've succeeded yet.
  */
-function generateBatches(scriptType, graphName, embeddingsStatusDict, fieldName, separateCollection, modelMetadata, overwriteExisting) {
+function generateBatches(scriptType, graphName, embeddingsStatusDict, modelMetadata, overwriteExisting) {
     // Create the embeddings run collection
-    const embeddingsRunColName = createAndAddEmbeddingsRunCollection(embeddingsStatusDict, fieldName, overwriteExisting);
+    const embeddingsRunColName = createAndAddEmbeddingsRunCollection(embeddingsStatusDict, overwriteExisting);
     const numberOfDocuments = getCountEmbeddingsRunCollection(embeddingsStatusDict);
 
     if (numberOfDocuments === 0) {
@@ -64,26 +64,26 @@ function generateBatches(scriptType, graphName, embeddingsStatusDict, fieldName,
         0,
         graphName,
         embeddingsStatusDict["collection"],
-        fieldName,
+        embeddingsStatusDict["field_name"],
         modelMetadata,
         embQ,
         embeddingsStatusDict["destination_collection"],
-        separateCollection,
+        embeddingsStatusDict["collection"] !== embeddingsStatusDict["destination_collection"],
         embeddingsRunColName
     );
     return true;
 }
 
-function generateBatchesForModel(graphName, embeddingsStatusDict, fieldName, separateCollection, modelMetadata, overwriteExisting = false) {
+function generateBatchesForModel(graphName, embeddingsStatusDict, modelMetadata, overwriteExisting = false) {
     switch (modelMetadata.model_type) {
         case modelTypes.WORD_EMBEDDING: {
-            return generateBatches(scripts.NODE, graphName, embeddingsStatusDict, fieldName, separateCollection, modelMetadata, overwriteExisting);
+            return generateBatches(scripts.NODE, graphName, embeddingsStatusDict, modelMetadata, overwriteExisting);
         }
         case modelTypes.GRAPH_MODEL: {
             if (!graphName) {
                 throw new Error("Requested to generate graph embeddings but no graph is provided");
             }
-            return generateBatches(scripts.GRAPH, graphName, embeddingsStatusDict, fieldName, separateCollection, modelMetadata, overwriteExisting);
+            return generateBatches(scripts.GRAPH, graphName, embeddingsStatusDict, modelMetadata, overwriteExisting);
         }
         default:
             throw new Error(`Error: unrecognized model type: ${modelMetadata.model_type}`);

--- a/services/emb_generation_service.js
+++ b/services/emb_generation_service.js
@@ -39,7 +39,7 @@ function queueBatch(scriptName, i, batchSize, numBatches, batchOffset, graphName
  * Queue batch jobs to generate embeddings for a specified model/scriptType.
  * Returns true if batch jobs have been queued. This does NOT mean that they've succeeded yet.
  */
-function generateBatches(scriptType, graphName, embeddingsStatusDict, modelMetadata, overwriteExisting) {
+function generateBatches(scriptType, embeddingsStatusDict, modelMetadata, overwriteExisting) {
     // Create the embeddings run collection
     const embeddingsRunColName = createAndAddEmbeddingsRunCollection(embeddingsStatusDict, overwriteExisting);
     const numberOfDocuments = getCountEmbeddingsRunCollection(embeddingsStatusDict);
@@ -62,7 +62,7 @@ function generateBatches(scriptType, graphName, embeddingsStatusDict, modelMetad
         batch_size,
         numBatches,
         0,
-        graphName,
+        embeddingsStatusDict["graph_name"],
         embeddingsStatusDict["collection"],
         embeddingsStatusDict["field_name"],
         modelMetadata,
@@ -74,16 +74,16 @@ function generateBatches(scriptType, graphName, embeddingsStatusDict, modelMetad
     return true;
 }
 
-function generateBatchesForModel(graphName, embeddingsStatusDict, modelMetadata, overwriteExisting = false) {
+function generateBatchesForModel(embeddingsStatusDict, modelMetadata, overwriteExisting = false) {
     switch (modelMetadata.model_type) {
         case modelTypes.WORD_EMBEDDING: {
-            return generateBatches(scripts.NODE, graphName, embeddingsStatusDict, modelMetadata, overwriteExisting);
+            return generateBatches(scripts.NODE, embeddingsStatusDict, modelMetadata, overwriteExisting);
         }
         case modelTypes.GRAPH_MODEL: {
             if (!graphName) {
                 throw new Error("Requested to generate graph embeddings but no graph is provided");
             }
-            return generateBatches(scripts.GRAPH, graphName, embeddingsStatusDict, modelMetadata, overwriteExisting);
+            return generateBatches(scripts.GRAPH, embeddingsStatusDict, modelMetadata, overwriteExisting);
         }
         default:
             throw new Error(`Error: unrecognized model type: ${modelMetadata.model_type}`);

--- a/services/emb_management_service.js
+++ b/services/emb_management_service.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const {embeddingsStatus} = require("../model/embeddings_status");
 const {pruneEmbeddings, getCountDocumentsWithoutEmbedding} = require("../services/emb_collections_service");
 const {updateEmbeddingsStatusDict} = require("../services/emb_status_service");

--- a/services/emb_management_service.js
+++ b/services/emb_management_service.js
@@ -61,7 +61,7 @@ function determineGenerationNeededForStatus(embeddingsStatusDict, overwriteExist
     };
 }
 
-function manageEmbeddingsForDocFieldAndModel(embStatusDict, graphName, modelMetadata, overwriteExisting) {
+function manageEmbeddingsForDocFieldAndModel(embStatusDict, modelMetadata, overwriteExisting) {
     let response_dict = {};
 
     // TODO: Decide on behavior if embeddings are no longer valid (e.g. the graph or collection has been deleted)
@@ -73,7 +73,7 @@ function manageEmbeddingsForDocFieldAndModel(embStatusDict, graphName, modelMeta
 
         if (shouldGenerate) {
             updateEmbeddingsStatusDict(embStatusDict, embeddingsStatus.RUNNING);
-            if (generateBatchesForModel(graphName, embStatusDict, modelMetadata, overwriteExisting)) {
+            if (generateBatchesForModel(embStatusDict, modelMetadata, overwriteExisting)) {
                 // NOP
             } else {
                 updateEmbeddingsStatusDict(embStatusDict, embeddingsStatus.COMPLETED);

--- a/services/emb_management_service.js
+++ b/services/emb_management_service.js
@@ -1,0 +1,83 @@
+const {embeddingsStatus} = require("../model/embeddings_status");
+const {pruneEmbeddings, getCountDocumentsWithoutEmbedding} = require("../services/emb_collections_service");
+const {updateEmbeddingsStatusDict} = require("../services/emb_status_service");
+const {generateBatchesForModel} = require("../services/emb_generation_service");
+
+function pruneEmbeddingsIfNeeded(embeddingsStatusDict, overwriteExisting) {
+    if (!overwriteExisting) {
+        switch (embeddingsStatusDict["status"]) {
+            case embeddingsStatus.DOES_NOT_EXIST:
+            case embeddingsStatus.RUNNING:
+            case embeddingsStatus.RUNNING_FAILED:
+                // Don't need to prune in these cases
+                return;
+            default:
+            // NOP
+        }
+    }
+    pruneEmbeddings(embeddingsStatusDict);
+}
+
+function determineGenerationNeededForStatus(embeddingsStatusDict, overwriteExisting) {
+    const start_msg = "Queued generation of embeddings!";
+    let message = "";
+    let shouldEmbed = true;
+
+    switch (embeddingsStatusDict["status"]) {
+        case embeddingsStatus.DOES_NOT_EXIST:
+        case embeddingsStatus.FAILED:
+            message = start_msg;
+            break;
+        case embeddingsStatus.RUNNING:
+        case embeddingsStatus.RUNNING_FAILED:
+            if (overwriteExisting) {
+                message = "Overwriting old embeddings. " + start_msg;
+            } else {
+                shouldEmbed = false;
+                message = "Generation of embeddings is already running!";
+            }
+            break;
+        case embeddingsStatus.COMPLETED:
+            // first check if we have any documents that don't already have an embedding
+            if (!overwriteExisting) {
+                if (getCountDocumentsWithoutEmbedding(embeddingsStatusDict, embeddingsStatusDict["field_name"]) !== 0) {
+                    message = "Adding new embeddings. " + start_msg;
+                } else {
+                    shouldEmbed = false;
+                    message = "These embeddings have already been generated!";
+                }
+            } else {
+                message = "Overwriting old embeddings. " + start_msg;
+            }
+            break;
+    }
+
+    return {
+        shouldGenerate: shouldEmbed,
+        message: message
+    };
+}
+
+function manageEmbeddingsForDocFieldAndModel(embStatusDict, graphName, modelMetadata, overwriteExisting) {
+    let response_dict = {};
+
+    pruneEmbeddingsIfNeeded(embStatusDict, overwriteExisting);
+
+    const {shouldGenerate, message} = determineGenerationNeededForStatus(embStatusDict, overwriteExisting);
+    response_dict["message"] = message;
+
+    if (shouldGenerate) {
+        updateEmbeddingsStatusDict(embStatusDict, embeddingsStatus.RUNNING);
+        if (generateBatchesForModel(graphName, embStatusDict, modelMetadata, overwriteExisting)) {
+            // NOP
+        } else {
+            updateEmbeddingsStatusDict(embStatusDict, embeddingsStatus.COMPLETED);
+            response_dict["message"] = "Nothing to embed.";
+        }
+    }
+
+    response_dict["embeddings_status_id"] = embStatusDict["_key"];
+    return response_dict;
+}
+
+exports.manageEmbeddingsForDocFieldAndModel = manageEmbeddingsForDocFieldAndModel;

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -41,10 +41,10 @@ function getEmbeddingsStatusDict(collectionName, destinationCollectionName, fiel
 /**
  * Get or create embeddings status. New embeddings status will be initialized to DOES_NOT_EXIST
  */
-function getOrCreateEmbeddingsStatusDict(collectionName, destinationCollectionName, fieldName, modelMetadata) {
-    const res = getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, getEmbeddingsFieldName(fieldName, modelMetadata))
+function getOrCreateEmbeddingsStatusDict(graphName, collectionName, destinationCollectionName, fieldName, modelMetadata) {
+    const res = getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, getEmbeddingsFieldName(fieldName, modelMetadata));
     if (res.length === 0) {
-        return createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata, embeddingsStatus.DOES_NOT_EXIST);
+        return createEmbeddingsStatus(graphName, collectionName, destinationCollectionName, fieldName, modelMetadata, embeddingsStatus.DOES_NOT_EXIST);
     }
     return res[0];
 }
@@ -52,14 +52,16 @@ function getOrCreateEmbeddingsStatusDict(collectionName, destinationCollectionNa
 /**
  * Create a new status of how the embeddings generation is going.
  */
-function createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata, startStatus = embeddingsStatus.DOES_NOT_EXIST) {
+function createEmbeddingsStatus(graphName, collectionName, destinationCollectionName, fieldName, modelMetadata, startStatus = embeddingsStatus.DOES_NOT_EXIST) {
     return createStatus(
+        graphName,
         collectionName,
         destinationCollectionName,
         getEmbeddingsFieldName(fieldName, modelMetadata),
         fieldName,
+        modelMetadata,
         startStatus,
-        new Date().toISOString()
+        new Date().toISOString(),
     );
 }
 

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -1,5 +1,5 @@
 "use strict";
-const {updateStatusByCollectionDestinationAndEmbName} = require("../db/embeddings_status");
+const {updateStatusByCollectionDestinationAndEmbName, updateEmbeddingsStatusByKey} = require("../db/embeddings_status");
 const {createStatus} = require("../db/embeddings_status");
 const {getStatusesByCollectionDestinationAndEmbName} = require("../db/embeddings_status");
 const {getEmbeddingsFieldName} = require("./emb_collections_service");
@@ -39,15 +39,26 @@ function getEmbeddingsStatusDict(collectionName, destinationCollectionName, fiel
 }
 
 /**
+ * Get or create embeddings status. New embeddings status will be initialized to DOES_NOT_EXIST
+ */
+function getOrCreateEmbeddingsStatusDict(collectionName, destinationCollectionName, fieldName, modelMetadata) {
+    const res = getStatusesByCollectionDestinationAndEmbName(collectionName, destinationCollectionName, getEmbeddingsFieldName(fieldName, modelMetadata))
+    if (res.length === 0) {
+        return createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata, embeddingsStatus.DOES_NOT_EXIST);
+    }
+    return res[0];
+}
+
+/**
  * Create a new status of how the embeddings generation is going.
  */
-function createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata) {
+function createEmbeddingsStatus(collectionName, destinationCollectionName, fieldName, modelMetadata, startStatus = embeddingsStatus.DOES_NOT_EXIST) {
     return createStatus(
         collectionName,
         destinationCollectionName,
         getEmbeddingsFieldName(fieldName, modelMetadata),
         fieldName,
-        embeddingsStatus.RUNNING,
+        startStatus,
         new Date().toISOString()
     );
 }
@@ -65,8 +76,23 @@ function updateEmbeddingsStatus(newStatus, collectionName, destinationCollection
     );
 }
 
+/**
+ * Update embeddings status with a new status
+ * @param embeddingsStatusDict
+ * @param newStatus
+ */
+function updateEmbeddingsStatusDict(embeddingsStatusDict, newStatus) {
+    updateEmbeddingsStatusByKey(
+        embeddingsStatusDict["_key"],
+        newStatus,
+        new Date().toISOString()
+    )
+}
+
 exports.getEmbeddingsStatus = getEmbeddingsStatus;
 exports.getEmbeddingsStatusDocId = getEmbeddingsStatusDocId;
 exports.createEmbeddingsStatus = createEmbeddingsStatus;
 exports.updateEmbeddingsStatus = updateEmbeddingsStatus;
 exports.getEmbeddingsStatusDict = getEmbeddingsStatusDict;
+exports.getOrCreateEmbeddingsStatusDict = getOrCreateEmbeddingsStatusDict;
+exports.updateEmbeddingsStatusDict = updateEmbeddingsStatusDict;

--- a/services/emb_status_service.js
+++ b/services/emb_status_service.js
@@ -46,6 +46,7 @@ function createEmbeddingsStatus(collectionName, destinationCollectionName, field
         collectionName,
         destinationCollectionName,
         getEmbeddingsFieldName(fieldName, modelMetadata),
+        fieldName,
         embeddingsStatus.RUNNING,
         new Date().toISOString()
     );

--- a/services/embeddings_run_service.js
+++ b/services/embeddings_run_service.js
@@ -24,12 +24,13 @@ function createEmbeddingsRunCollection(embeddingsStatusDict) {
     return embeddingsRunCol;
 }
 
-function createAndAddEmbeddingsRunCollectionSameCollection(embeddingsStatusDict, sourceFieldName) {
+function createAndAddEmbeddingsRunCollectionSameCollection(embeddingsStatusDict) {
     // Clear any docs first
     clearEmbeddingsRunCollection(embeddingsStatusDict);
     const embeddingsRunCol = createEmbeddingsRunCollection(embeddingsStatusDict);
     const dCol = db._collection(embeddingsStatusDict["destination_collection"]);
     const embedding_field_name = embeddingsStatusDict["emb_field_name"];
+    const sourceFieldName = embeddingsStatusDict["field_name"];
     query`
         FOR doc in ${dCol}
           FILTER doc.${sourceFieldName} != null
@@ -38,11 +39,12 @@ function createAndAddEmbeddingsRunCollectionSameCollection(embeddingsStatusDict,
     `;
 }
 
-function createAndAddEmbeddingsRunCollectionSeparateCollection(embeddingsStatusDict, sourceFieldName) {
+function createAndAddEmbeddingsRunCollectionSeparateCollection(embeddingsStatusDict) {
     // Clear any docs first
     clearEmbeddingsRunCollection(embeddingsStatusDict);
     const embeddingsRunCol = createEmbeddingsRunCollection(embeddingsStatusDict);
     const sourceCol = db._collection(embeddingsStatusDict["collection"]);
+    const sourceFieldName = embeddingsStatusDict["field_name"];
     const dCol = db._collection(embeddingsStatusDict["destination_collection"]);
     const embedding_field_name = embeddingsStatusDict["emb_field_name"];
     query`
@@ -61,11 +63,12 @@ function createAndAddEmbeddingsRunCollectionSeparateCollection(embeddingsStatusD
     return embeddingsRunCol.name();
 }
 
-function createAndAddEmbeddingsRunCollectionAllValidDocs(embeddingsStatusDict, sourceFieldName) {
+function createAndAddEmbeddingsRunCollectionAllValidDocs(embeddingsStatusDict) {
     // Clear any docs first
     clearEmbeddingsRunCollection(embeddingsStatusDict);
     const embeddingsRunCol = createEmbeddingsRunCollection(embeddingsStatusDict);
     const sourceCol = db._collection(embeddingsStatusDict["collection"]);
+    const sourceFieldName = embeddingsStatusDict["field_name"];
     query`
         FOR doc in ${sourceCol}
           FILTER doc.${sourceFieldName} != null
@@ -74,16 +77,16 @@ function createAndAddEmbeddingsRunCollectionAllValidDocs(embeddingsStatusDict, s
     return embeddingsRunCol.name();
 }
 
-function createAndAddEmbeddingsRunCollection(embeddingsStatusDict, sourceFieldName, overwriteExisting) {
+function createAndAddEmbeddingsRunCollection(embeddingsStatusDict, overwriteExisting) {
     if (overwriteExisting) {
         // here we just add all valid docs!
-        return createAndAddEmbeddingsRunCollectionAllValidDocs(embeddingsStatusDict, sourceFieldName);
+        return createAndAddEmbeddingsRunCollectionAllValidDocs(embeddingsStatusDict);
     }
 
     if (embeddingsStatusDict["destination_collection"] === embeddingsStatusDict["collection"]) {
-        return createAndAddEmbeddingsRunCollectionSameCollection(embeddingsStatusDict, sourceFieldName);
+        return createAndAddEmbeddingsRunCollectionSameCollection(embeddingsStatusDict);
     } else {
-        return createAndAddEmbeddingsRunCollectionSeparateCollection(embeddingsStatusDict, sourceFieldName);
+        return createAndAddEmbeddingsRunCollectionSeparateCollection(embeddingsStatusDict);
     }
 }
 

--- a/services/model_metadata_service.js
+++ b/services/model_metadata_service.js
@@ -17,7 +17,22 @@ function retrieveModel(modelName, modelType) {
         FILTER m.name == ${modelName}
         AND m.model_type == ${modelType}
         RETURN m
-    `.toArray()
+    `.toArray();
+
+    if (model_info.length > 0) {
+        return model_info[0];
+    }
+    // if we don't have a model, return null
+    return null;
+}
+
+function getModelByKey(modelKey) {
+    const metadata_col = db._collection(metadataCollectionName);
+    const model_info = query`
+        FOR m in ${metadata_col}
+        FILTER m._key == ${modelKey}
+        RETURN m
+    `.toArray();
 
     if (model_info.length > 0) {
         return model_info[0];
@@ -27,3 +42,4 @@ function retrieveModel(modelName, modelType) {
 }
 
 exports.retrieveModel = retrieveModel;
+exports.getModelByKey = getModelByKey;

--- a/utils/embeddings_target.js
+++ b/utils/embeddings_target.js
@@ -1,0 +1,17 @@
+/**
+ * This module contains helper functions for checking if an embeddings target is still valid
+ */
+"use strict";
+const {checkGraphIsPresent, checkCollectionIsPresent} = require("./db");
+
+function embeddingsTargetsAreValid(graphName, collectionName) {
+    if (graphName !== undefined && graphName !== null) {
+        if (!checkGraphIsPresent(graphName)) {
+            return false;
+        }
+    }
+    // Collection is always present (as per schema)
+    return checkCollectionIsPresent(collectionName);
+}
+
+exports.embeddingsTargetsAreValid = embeddingsTargetsAreValid;


### PR DESCRIPTION
This PR includes:
- Refactoring of a fat controller
- Adding additional fields to the embeddings status document schema - the `fieldName`, `graphName` and information about the model used (the key and name).
- Adding the scheduled management of embeddings collections - by using a Foxx queue job at an interval. The interval can be adjusted by the user - the default is currently set to once every 2 hours (default interval is open for discussion).
- Adding a "kill switch" option for disabling all background jobs - and another for disabling background management. If background management is disabled then the recurring job will no longer be queued - and it will be up to the user to re-activate the job
- Fixes for a bug that occurred when a target graph or collection has been deleted.